### PR TITLE
[RTR-85] Designfix : 랜딩페이지 및 로그인 페이지 레이아웃 수정

### DIFF
--- a/public/icons/home/left-arrow.svg
+++ b/public/icons/home/left-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="16" viewBox="0 0 12 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 15.0001L1 7.89563L11 1.00012" stroke="#98C2FE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -7,25 +7,32 @@ const LandingPage = () => {
 
   return (
     <Layout>
-      <div className=" mt-[71.394%] flex flex-col justify-center items-center">
-        {/* 아이콘 영역 */}
-        <div className=" w-full max-w-[192px] max-h-[192px]">
+      <div className=" mt-[50%] mb-auto flex flex-col justify-center items-center gap-4">
+        {/* 아이콘, 로고 영역 */}
+        <div className=" w-full max-w-[146px] max-h-[164px]">
           <img src="/icons/symbol.svg" alt="리트리버 캐릭터 로고" />
         </div>
-        {/* 버튼 영역 - 대여하기, 관리자로 로그인 */}
-        <div className="flex flex-col justify-center items-center w-full max-w-[305px] pt-[9.564%]">
-          {/* TODO: 라우팅 경로 짜기 */}
-          <Button variant="primary" size="lg" onClick={() => navigate("")}>
-            <p>대여하기</p>
-          </Button>
-          {/* 관리자 로그인 버튼 : /login 으로 이동 */}
-          <button
-            onClick={() => navigate("/login")}
-            className="w-full max-w-[89px] text-[0.875rem] text-center text-[#000000] opacity-50 mt-[3.74%] cursor-pointer hover:opacity-80"
-          >
-            관리자로 로그인
-          </button>
+        <div className="w-full max-w-[240px]">
+          <img
+            className="w-full"
+            src="/icons/retrivr_text_primary.svg"
+            alt="리트리버 텍스트 로고"
+          />
         </div>
+        <p className="text-neutral-gray-3 text-12px">
+          손 쉬운 대여 장부 관리 리트리버
+        </p>
+      </div>
+      {/* 버튼 영역 - 대여하기, 관리자로 로그인 */}
+      <div className="flex flex-col justify-center items-center w-full mt-auto mb-[12%] gap-2">
+        {/* TODO: 라우팅 경로 짜기 */}
+        <Button variant="primary" size="lg" onClick={() => navigate("")}>
+          대여하기
+        </Button>
+        {/* 관리자 로그인 버튼 : /login 으로 이동 */}
+        <Button variant="gray" size="lg" onClick={() => navigate("/login")}>
+          관리자로 로그인
+        </Button>
       </div>
     </Layout>
   );

--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -8,6 +8,14 @@ const LoginPage = () => {
 
   return (
     <Layout>
+      {/* 뒤로가기 버튼 : 랜딩페이지로 이동 */}
+      <button
+        className="absolute top-[7%] left-[7%] object-fit"
+        onClick={() => navigate(-1)}
+      >
+        <img src="/icons/home/left-arrow.svg" alt="뒤로가기 버튼" />
+      </button>
+      {/* 화면 영역 - 로고, 입력창, 버튼 영역 */}
       <div className="flex flex-col w-full h-screen max-h-[874px] items-center px-[7.962%]">
         {/* 로고 영역 - 리트리버 로고 */}
         <div className="w-full max-w-[278.242px] mt-[59.765%]">
@@ -18,10 +26,14 @@ const LoginPage = () => {
           />
         </div>
         {/* 로그인 영역 - 입력창, 로그인 버튼 */}
-        <form className="flex flex-col w-full items-center mt-[23.888%] gap-3">
+        <form className="flex flex-col w-full  mt-[23.888%] gap-3">
+          {/* 텍스트 영역 - 관리자 로그인 */}
+          <p className="text-neutral-gray-1 text-16px font-bold">
+            관리자 로그인
+          </p>
           <CommonInput placeholder="이메일" type="email" />
           <CommonInput placeholder="비밀번호" type="password" />
-          {/* TODO : 로그인 페이지 라우팅 설정 */}
+          {/* TODO : 로그인 페이지 라우팅 및 이벤트 핸들러 설정 */}
           <Button variant="primary" size="lg" onClick={() => navigate("")}>
             로그인
           </Button>
@@ -33,9 +45,10 @@ const LoginPage = () => {
             이메일 / 비밀번호 찾기
           </button>
         </form>
+
         {/* 회원가입 영역 - 텍스트, 회원가입 버튼 */}
         <div className="flex flex-col w-full items-center gap-3 mt-auto mb-[13.02%]">
-          <p className="text-center text-[#9c9c9c] text-[0.875rem] font-normal leading-none">
+          <p className="text-center text-primary text-14px font-normal leading-none">
             회원이 아니신가요?
           </p>
           {/* 회원가입 버튼 : /register 로 이동 */}


### PR DESCRIPTION
## 📌 Related Issues

- close #24 

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

랜딩페이지와 로그인 페이지 디자인을 Figma 최종 UI에 맞게 수정했습니다.

## ⭐ PR Point (To Reviewer)

- [로그인페이지]에서 뒤로가기 버튼이 굳이 있어야할지 잘 모르겠습니다. 
- 브라우저(데스크톱, 모바일)에서 뒤로가기를 지원해주기 때문에 굳이 있어야하는지는 잘 모르겠습니다.

## 📷 Screenshot

[랜딩페이지]
<img width="465" height="908" alt="image" src="https://github.com/user-attachments/assets/9f7c71d7-f91e-4843-9d6b-aa5e30513553" />

[로그인 페이지]
<img width="443" height="908" alt="image" src="https://github.com/user-attachments/assets/03e6fb65-d90d-4a56-9863-a830fb4a9daa" />


## 🔔 ETC
- 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신기능**
  * 랜딩 페이지에 로고 이미지와 부제 텍스트 추가
  * 대여하기 및 관리자로 로그인 버튼 레이아웃 개선
  * 로그인 페이지에 뒤로가기 버튼 추가
  * 로그인 페이지 폼 스타일 및 간격 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->