### PR TITLE
[RTR-89] Feature: 관리자 회원가입 시 이메일 인증 코드 요청 및 검증 API 구현

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -8,12 +8,12 @@ import type {
 
 //
 // 1. 회원가입용 이메일 인증 코드 전송 API (POST)
-// 엔드포인트 : "/api/public/v1/auth/signup/email-code/send"
+// 엔드포인트 : "/api/public/v1/email/verification"
 export const sendEmailCode = async (
   data: SendEmailCodeRequest,
 ): Promise<SendEmailCodeResponse> => {
   const response = await apiClient.post<SendEmailCodeResponse>(
-    "/api/public/v1/auth/signup/email-code/send",
+    "/api/public/v1/email/verification",
     data,
   );
   return response.data;
@@ -21,12 +21,12 @@ export const sendEmailCode = async (
 
 //
 // 2. 회원가입용 이메일 인증 코드 전송 API (POST)
-// 엔드포인트 : "/api/public/v1/auth/signup/email-code/verify"
+// 엔드포인트 : "/api/public/v1/email/verification/verify"
 export const verifyEmailCode = async (
   data: VerifyEmailCodeRequest,
 ): Promise<VerifyEmailCodeResponse> => {
   const response = await apiClient.post<VerifyEmailCodeResponse>(
-    "/api/public/v1/auth/signup/email-code/verify",
+    "/api/public/v1/email/verification/verify",
     data,
   );
   return response.data;

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -1,15 +1,17 @@
-// 1. 회원가입용 이메일 인증 코드 전송
+export type EmailVerificationPurpose = "SIGNUP" | "PASSWORD_RESET" | "LOGIN";
 
+// 1. 회원가입용 이메일 인증 코드 전송
 // 1-1. 이메일 인증 코드 전송 요청 바디
 export interface SendEmailCodeRequest {
   email: string; // 여기로 인증 코드가 전송될 것
+  purpose: EmailVerificationPurpose; // 인증 코드 발송 목적
 }
 
 // 1-2. 이메일 인증 코드 전송 응답 바디
 export interface SendEmailCodeResponse {
-  success: boolean; // 이메일 전송 여부
+  email: string; // 인증 코드를 받은 이메일
+  purpose: EmailVerificationPurpose; // 인증 코드 발송 목적
   expiresInSeconds: number; // 인증 코드 유효시간
-  message: string; // "인증 코드가 이메일로 발송되었습니다."
 }
 
 // 2. 회원가입용 이메일 인증 코드 검증
@@ -17,6 +19,7 @@ export interface SendEmailCodeResponse {
 // 2-1. 이메일 인증 코드 검증 요청 바디
 export interface VerifyEmailCodeRequest {
   email: string; // 인증 코드 받았던 이메일
+  purpose: "SIGNUP"; // API 요청 목적
   code: string; // 이메일로 왔던 인증코드
 }
 

--- a/src/components/CommonInput.tsx
+++ b/src/components/CommonInput.tsx
@@ -8,7 +8,8 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 const sizeStyles: Record<"small" | "medium" | "large", string> = {
   small: "max-w-[180px] min-h-[36px] px-3 py-2 text-[0.875rem] rounded-[10px]",
-  medium: "max-w-[260px] min-h-[42px] px-4 py-3 text-[0.9375rem] rounded-[12px]",
+  medium:
+    "max-w-[260px] min-h-[42px] px-4 py-3 text-[0.9375rem] rounded-[12px]",
   large: "max-w-[338px] min-h-[48px] px-5 py-4 text-[1rem] rounded-[14px]",
 };
 
@@ -19,7 +20,10 @@ const wrapperSizeStyles: Record<"small" | "medium" | "large", string> = {
 };
 
 const CommonInput = forwardRef<HTMLInputElement, InputProps>(
-  ({ inputSize = "large", isRequired, className, type = "text", ...props }, ref) => {
+  (
+    { inputSize = "large", isRequired, className, type = "text", ...props },
+    ref,
+  ) => {
     return (
       <div
         className={`flex flex-col w-full items-center gap-2 ${wrapperSizeStyles[inputSize]}`}
@@ -31,9 +35,9 @@ const CommonInput = forwardRef<HTMLInputElement, InputProps>(
           required={isRequired} // 해당 입력의 필수 여부 : true, false 중 하나
           className={`
             w-full bg-[#F8F9F9] text-[#333] font-[Pretendard] outline-hidden transition-all
-            placeholder:text-gray-400 leading-none
+            placeholder:text-gray-400 leading-none text-14px
             focus:ring-2 focus:ring-blue-100
-            transition duration-300 ease-in-out focus:-translate-y-1 focus:scale-101
+            
             ${sizeStyles[inputSize]}
             ${className ?? ""}
           `}

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -9,7 +9,6 @@ export const useSendEmailCode = () => {
     mutationFn: sendEmailCode,
     onSuccess: () => {
       // 성공 시 백엔드에서 보내준 메시지를 활용 가능
-      // 예: alert(data.message) 또는 토스트(Toast) 알림 띄우기
       console.log("이메일 발송 성공:");
 
       // data.expiresInSeconds (600)을 활용해 여기서부터 타이머 시작 가능

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -7,10 +7,10 @@ import { sendEmailCode, verifyEmailCode } from "../../api/auth/auth.api";
 export const useSendEmailCode = () => {
   return useMutation({
     mutationFn: sendEmailCode,
-    onSuccess: (data) => {
+    onSuccess: () => {
       // 성공 시 백엔드에서 보내준 메시지를 활용 가능
       // 예: alert(data.message) 또는 토스트(Toast) 알림 띄우기
-      console.log("이메일 발송 성공:", data.message);
+      console.log("이메일 발송 성공:");
 
       // data.expiresInSeconds (600)을 활용해 여기서부터 타이머 시작 가능
     },
@@ -30,7 +30,7 @@ export const useVerifyEmailCode = () => {
     onSuccess: () => {
       console.log("인증 성공");
     },
-    onError: (error) => {
+    onError: (error: any) => {
       console.log("인증 실패", error);
     },
   });

--- a/src/pages/admin/RegisterPage.tsx
+++ b/src/pages/admin/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   useSendEmailCode,
   useVerifyEmailCode,
@@ -28,11 +28,20 @@ const RegisterPage = () => {
       {
         onSuccess: (data) => {
           // 예: data.expiresInSeconds 사용
+          alert("이메일로 인증 코드가 전송되었습니다.");
           setTimeLeft(data.expiresInSeconds);
           setIsTimerActive(true);
         },
       },
     );
+  };
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, "0");
+    const s = (seconds % 60).toString().padStart(2, "0");
+    return `${m}:${s}`;
   };
   {
     /* 인증 코드 관련 */
@@ -40,10 +49,6 @@ const RegisterPage = () => {
 
   // 인증코드: number
   const [authCode, setAuthCode] = useState("");
-
-  // 인증 유효시간: 현재 600초로 설정
-  const [timeLeft, setTimeLeft] = useState(0);
-  const [isTimerActive, setIsTimerActive] = useState(false);
 
   // 인증이 최종적으로 완료되었는지에 대한 여부
   const [isVerified, setIsVerified] = useState(false);
@@ -68,6 +73,24 @@ const RegisterPage = () => {
       },
     );
   };
+
+  // 인증 유효시간: 현재 600초로 설정
+  const [timeLeft, setTimeLeft] = useState(0);
+  const [isTimerActive, setIsTimerActive] = useState(false);
+  // 타이머 useEffect
+  useEffect(() => {
+    if (!isTimerActive) return;
+    if (timeLeft <= 0) {
+      setIsTimerActive(false);
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setTimeLeft((prev) => prev - 1);
+    }, 1000);
+
+    return () => window.clearInterval(timerId);
+  }, [isTimerActive, timeLeft]);
 
   return (
     <Layout>
@@ -116,13 +139,22 @@ const RegisterPage = () => {
             </Button>
           </div>
           {/* 인증 번호 확인 영역 */}
-          <div className="flex justify-between">
+          <div className="flex justify-between relative">
             <CommonInput
               placeholder="인증번호 입력"
+              type="numeric"
+              maxLength={6}
               value={authCode}
               onChange={(e) => setAuthCode(e.target.value)}
               disabled={!isTimerActive || isVerified} // 타이머가 끝났거나 인증 완료 시 입력 불가
             />
+            {/* 남은 시간 표시 */}
+            <span
+              className="absolute 
+            top-4.5 right-30 ml-2 w-14 text-right text-primary text-14px leading-none"
+            >
+              {isTimerActive && timeLeft > 0 ? formatTime(timeLeft) : ""}
+            </span>
             <Button
               variant="primary"
               size="sm"

--- a/src/pages/admin/RegisterPage.tsx
+++ b/src/pages/admin/RegisterPage.tsx
@@ -23,9 +23,17 @@ const RegisterPage = () => {
     if (!email) return alert("이메일을 입력해주세요.");
 
     // API 요청 실행
-    sendCode({ email });
+    sendCode(
+      { email, purpose: "SIGNUP" },
+      {
+        onSuccess: (data) => {
+          // 예: data.expiresInSeconds 사용
+          setTimeLeft(data.expiresInSeconds);
+          setIsTimerActive(true);
+        },
+      },
+    );
   };
-
   {
     /* 인증 코드 관련 */
   }
@@ -47,7 +55,7 @@ const RegisterPage = () => {
     if (!authCode) return alert("인증번호를 입력해주세요.");
 
     verifyCode(
-      { email, code: authCode }, // 이메일과 인증번호를 함께 백엔드로 전달
+      { email, code: authCode, purpose: "SIGNUP" }, // 이메일과 인증번호를 함께 백엔드로 전달
       {
         onSuccess: () => {
           alert("이메일 인증이 완료되었습니다.");

--- a/src/pages/admin/RegisterPage.tsx
+++ b/src/pages/admin/RegisterPage.tsx
@@ -142,7 +142,9 @@ const RegisterPage = () => {
           <div className="flex justify-between relative">
             <CommonInput
               placeholder="인증번호 입력"
-              type="numeric"
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]{6}"
               maxLength={6}
               value={authCode}
               onChange={(e) => setAuthCode(e.target.value)}
@@ -155,6 +157,7 @@ const RegisterPage = () => {
             >
               {isTimerActive && timeLeft > 0 ? formatTime(timeLeft) : ""}
             </span>
+            {/* 인증 코드 확인 버튼 */}
             <Button
               variant="primary"
               size="sm"


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #23 

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

관리자 회원가입 이메일 인증코드 관련 API 구현 완료했습니다. 

코드는 현재 123456으로 고정이 돼있고, 인증 시도 시 제대로 됩니다.


## ⭐ PR Point (To Reviewer)

다만, 첫 인증코드 입력 후 검증 때 유효하지 않은 인증 코드를 입력하고, 정상적인 코드를 재입력 시에도 에러 메시지가 뜹니다. 백엔드에서 해당 부분 검증이 필요할 것 같습니다.

## 📷 Screenshot

<img width="731" height="971" alt="image" src="https://github.com/user-attachments/assets/dff40e1b-c4be-493f-8770-297b2d83ef74" />


## 🔔 ETC



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경사항

* **새 기능**
  * 이메일 인증에 타이머 기반 유효시간 표시 추가 (가입 플로우)
  * 이메일 인증 요청에 목적(purpose) 구분 추가하여 가입/재설정/로그인 지원

* **개선사항**
  * 인증 코드 입력 UX 개선: 숫자 전용 입력 및 최대 6자리 제약 강화
  * 입력 컴포넌트 플레이스홀더 글꼴 크기 및 포커스 동작 조정
  * 이메일 인증 흐름의 응답 처리 및 안내 동작 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->