### PR TITLE
[RTR-103] [페이지/대여자] 홈화면 페이지 1차 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import HomePage from "./pages/admin/HomePage";
 import LandingPage from "./pages/LandingPage";
 import RegisterPage from "./pages/admin/RegisterPage";
 import RentalRequestPage from "./pages/admin/RentalRequestPage";
+import ClientHomePage from "./pages/client/ClientHomePage";
 
 function App() {
   return (
@@ -22,12 +23,16 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
       </Routes>
       <Routes>
-        {/* 홈 페이지 */}
+        {/* 관리자 홈 페이지 */}
         <Route path="/home" element={<HomePage />} />
       </Routes>
       <Routes>
         {/* 대여 요청 확인 페이지 */}
         <Route path="/rental-request" element={<RentalRequestPage />} />
+      </Routes>
+      <Routes>
+        {/* 대여자 홈 페이지 */}
+        <Route path="/client-home" element={<ClientHomePage />} />
       </Routes>
       <Routes>
         {/* 테스트 페이지 */}

--- a/src/components/client/RentalAvailableItemCard.tsx
+++ b/src/components/client/RentalAvailableItemCard.tsx
@@ -48,7 +48,7 @@ const RentalAvailableItemCard = ({
             <ul className="text-12px text-neutral-gray-3 mb-6">
               <li>
                 대여 기간 :{" "}
-                <span className="text-primary">{item.rentalDuration}</span>
+                <span className="text-primary">{item.rentalDuration}일</span>
               </li>
               <li>
                 보증 물품 :{" "}

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -8,19 +8,73 @@ import RentalAvailableItemCard from "../components/client/RentalAvailableItemCar
 import Header from "../components/Header";
 import type { ItemRequest } from "../types/item";
 
-const DUMMY_ITEM_REQUEST: ItemRequest = {
-  item: {
-    itemId: 1,
-    name: "C타입 충전기",
-    availableQuantity: 3,
-    totalQuantity: 5,
-    isActive: true,
-    rentalDuration: 3,
-    description: "어댑터 미포함",
-    guaranteedGoods: "학생증 또는 신분증",
+export const DUMMY_ITEM_REQUESTS: ItemRequest[] = [
+  {
+    item: {
+      itemId: 1,
+      name: "C타입 충전기",
+      availableQuantity: 3,
+      totalQuantity: 5,
+      isActive: true,
+      rentalDuration: 3,
+      description: "어댑터 미포함",
+      guaranteedGoods: "학생증 또는 신분증",
+    },
+    nextCursor: 2,
   },
-  nextCursor: 2,
-};
+  {
+    item: {
+      itemId: 2,
+      name: "멀티탭 (4구)",
+      availableQuantity: 5,
+      totalQuantity: 10,
+      isActive: true,
+      rentalDuration: 2,
+      description: "최대 2200W 사용 가능",
+      guaranteedGoods: "학생증",
+    },
+    nextCursor: 3,
+  },
+  {
+    item: {
+      itemId: 3,
+      name: "보조 배터리",
+      availableQuantity: 1,
+      totalQuantity: 8,
+      isActive: true,
+      rentalDuration: 1,
+      description: "케이블 별도 지참",
+      guaranteedGoods: "학생증 또는 신분증",
+    },
+    nextCursor: 4,
+  },
+  {
+    item: {
+      itemId: 4,
+      name: "우산",
+      availableQuantity: 7,
+      totalQuantity: 20,
+      isActive: true,
+      rentalDuration: 1,
+      description: "반납 시 상태 확인",
+      guaranteedGoods: "학생증",
+    },
+    nextCursor: 5,
+  },
+  {
+    item: {
+      itemId: 5,
+      name: "노트북 거치대",
+      availableQuantity: 2,
+      totalQuantity: 4,
+      isActive: true,
+      rentalDuration: 7,
+      description: "알루미늄 재질",
+      guaranteedGoods: "학생증 또는 신분증",
+    },
+    nextCursor: 6,
+  },
+];
 
 const TestPage = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -76,7 +130,7 @@ const TestPage = () => {
   return (
     <div className="p-10 flex flex-col gap-5">
       <h1 className="text-xl font-bold">대여 가능 물품 컴포넌트 테스트</h1>
-      <RentalAvailableItemCard itemInfo={DUMMY_ITEM_REQUEST} />
+      <RentalAvailableItemCard itemInfo={DUMMY_ITEM_REQUESTS[0]} />
       <h1 className="text-xl font-bold">헤더 컴포넌트 테스트</h1>
       <div className="flex flex-col bg-neutral-gray-4 opacity-90 w-[700px] h-[500px] items-center p-10 gap-30">
         <Header name="" pageName="회원가입"></Header>

--- a/src/pages/client/ClientHomePage.tsx
+++ b/src/pages/client/ClientHomePage.tsx
@@ -1,0 +1,119 @@
+import { Layout } from "../../components/Layout";
+import RentalAvailableItemCard from "../../components/client/RentalAvailableItemCard";
+import type { ItemRequest } from "../../types/item";
+
+// 더미데이터 -> API 연동 후 삭제 예정
+const DUMMY_ITEM_REQUESTS: ItemRequest[] = [
+  {
+    item: {
+      itemId: 1,
+      name: "C타입 충전기",
+      availableQuantity: 3,
+      totalQuantity: 5,
+      isActive: true,
+      rentalDuration: 3,
+      description: "어댑터 미포함",
+      guaranteedGoods: "학생증 또는 신분증",
+    },
+    nextCursor: 2,
+  },
+  {
+    item: {
+      itemId: 2,
+      name: "멀티탭 (4구)",
+      availableQuantity: 5,
+      totalQuantity: 10,
+      isActive: true,
+      rentalDuration: 2,
+      description: "최대 2200W 사용 가능",
+      guaranteedGoods: "학생증",
+    },
+    nextCursor: 3,
+  },
+  {
+    item: {
+      itemId: 3,
+      name: "보조 배터리",
+      availableQuantity: 1,
+      totalQuantity: 8,
+      isActive: true,
+      rentalDuration: 1,
+      description: "케이블 별도 지참",
+      guaranteedGoods: "학생증 또는 신분증",
+    },
+    nextCursor: 4,
+  },
+  {
+    item: {
+      itemId: 4,
+      name: "우산",
+      availableQuantity: 7,
+      totalQuantity: 20,
+      isActive: true,
+      rentalDuration: 1,
+      description: "반납 시 상태 확인",
+      guaranteedGoods: "학생증",
+    },
+    nextCursor: 5,
+  },
+  {
+    item: {
+      itemId: 5,
+      name: "노트북 거치대",
+      availableQuantity: 2,
+      totalQuantity: 4,
+      isActive: true,
+      rentalDuration: 7,
+      description: "알루미늄 재질",
+      guaranteedGoods: "학생증 또는 신분증",
+    },
+    nextCursor: 6,
+  },
+];
+
+const ClientHome = () => {
+  return (
+    <Layout>
+      {/* 화면 상단 영역 - 대여지 프로필 사진, 대여지명 */}
+      <div
+        className="w-full max-w-[402px] h-[20%] max-h-[180px] pt-[12.66%]
+      px-[7.464%] bg-home-gradient rounded-bl-[45px]"
+      >
+        {/* 상단 로고 텍스트 및 사람 아이콘 */}
+        <div className="w-full flex justify-between">
+          <img src="/icons/home/retrivr_text_outline.svg" alt="로고 텍스트" />
+          <img src="/icons/home/man_icon.svg" alt="사람 아이콘" />
+        </div>
+        <div className="flex w-full max-h-[72px] mt-[50.64px]">
+          {/* 프로필 사진 */}
+          <div />
+          {/* 주소 및 단체 이름 */}
+          <div className="pl-[12px] pt-[12.68px] gap-[4px] font-[Pretendard] leading-none flex flex-col">
+            <span className="text-neutral-dark text-start text-[12px] font-[400]">
+              {/* 주소 영역 - 아직 구현 X */}
+            </span>
+            <span className="text-neutral-white text-start text-[16px] font-[600]">
+              이름
+            </span>
+          </div>
+        </div>
+      </div>
+      {/* 화면 하단 영역 - 대여 가능 물품 리스트 */}
+      <div className="flex flex-col font-[Pretendard] pt-10 px-6.5 gap-5">
+        <p className="text-18px text-secondary-2 opacity-[0.9] font-[700]">
+          대여 가능 물품
+        </p>
+        <div className="flex flex-col gap-3.5">
+          {DUMMY_ITEM_REQUESTS.map((itemRequest) => (
+            <RentalAvailableItemCard
+              key={itemRequest.item.itemId}
+              itemInfo={itemRequest}
+            />
+          ))}
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default ClientHome;


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #37 

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- 대여자 홈 화면 1차 구현했습니다. 해당 페이지 API 연동 필요하고, 현재는 더미데이터로 구성돼있습니다. 

## ⭐ PR Point (To Reviewer)

- commit 메시지에 'Edit'으로 잘못 표기했습니다. 다음부터 주의하도록 하겠습니다. 

## 📷 Screenshot

<img width="463" height="923" alt="image" src="https://github.com/user-attachments/assets/ef6ac3ac-3a8f-4df3-bf35-7d0d592ef7cf" />

## 🔔 ETC

- 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클라이언트 홈 페이지 추가: 헤더, 배너, 대여 가능 물품 목록 제공
  * 클라이언트 홈으로의 새로운 라우팅 경로 추가

* **UI 개선**
  * 대여 기간 표시에 "일" 단위 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->