### PR TITLE
[RTR-144] 대여 요청 페이지 조회 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -2,6 +2,7 @@ import type {
   AdminItemListResponse,
   AdminRentalItemSummaryResponse,
   AdminOverdueRentalListResponse,
+  AdminRentalRequestListResponse,
 } from "./admin.type";
 import { apiClient } from "../core";
 
@@ -52,6 +53,26 @@ export const requestAdminOverdueRentalList = async (
 ): Promise<AdminOverdueRentalListResponse> => {
   const response = await apiClient.get<AdminOverdueRentalListResponse>(
     "/api/admin/v1/rentals/overdue",
+    { params },
+  );
+  return response.data;
+};
+
+// 대여 요청 목록 조회
+// - 관리자 대여 요청 확인 페이지에서 사용
+// - cursor: 마지막으로 조회된 rentalId (다음 페이지 조회 시 사용)
+// - size: 한 번에 가져올 대여 요청 수
+// GET /api/admin/v1/rentals/requests
+export interface AdminRentalRequestListParams {
+  cursor?: number;
+  size?: number;
+}
+
+export const requestAdminRentalRequestList = async (
+  params?: AdminRentalRequestListParams,
+): Promise<AdminRentalRequestListResponse> => {
+  const response = await apiClient.get<AdminRentalRequestListResponse>(
+    "/api/admin/v1/rentals/requests",
     { params },
   );
   return response.data;

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -61,3 +61,26 @@ export interface AdminOverdueRentalListResponse {
   canSendOverdueSms: boolean;
   nextCursor?: number;
 }
+
+// 대여 요청 목록 조회 응답
+// GET /api/admin/v1/rentals/requests
+// 관리자 대여 요청 확인 페이지에서 사용
+export interface AdminRentalRequestItem {
+  rentalId: number;
+  itemId: number;
+  itemName: string;
+  itemUnitId: number;
+  itemUnitCode: string;
+  totalQuantity: number;
+  availableQuantity: number;
+  borrowerName: string;
+  borrowerMajor: string;
+  borrowerStudentNumber: string;
+  guaranteedGoods: string;
+  requestedAt: string;
+}
+
+export interface AdminRentalRequestListResponse {
+  requests: AdminRentalRequestItem[];
+  nextCursor?: number;
+}

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -3,6 +3,7 @@ import {
   requestAdminItemList,
   requestAdminRentalItemSummaryList,
   requestAdminOverdueRentalList,
+  requestAdminRentalRequestList,
 } from "../../api/admin/admin.api";
 
 // 관리자 물품 목록 조회 (관리자 전용 API 사용)
@@ -36,6 +37,18 @@ export const useAdminOverdueRentalList = () => {
   return useQuery({
     queryKey: ["adminOverdueRentals"],
     queryFn: () => requestAdminOverdueRentalList({ size: 20 }),
+    retry: false,
+  });
+};
+
+// 대여 요청 목록 조회
+// - 관리자 대여 요청 확인 페이지에서 사용
+// - size 기본값 15개
+// - 서버 캐시 키: ["adminRentalRequests"]
+export const useAdminRentalRequestList = () => {
+  return useQuery({
+    queryKey: ["adminRentalRequests"],
+    queryFn: () => requestAdminRentalRequestList({ size: 15 }),
     retry: false,
   });
 };

--- a/src/pages/admin/RentalRequestPage.tsx
+++ b/src/pages/admin/RentalRequestPage.tsx
@@ -2,28 +2,55 @@ import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import RentalConfirmCard from "../../components/cards/admin/rental/RentalConfirmCard";
 import type { RentalRequest } from "../../types/rental";
-
-const sampleRental: RentalRequest = {
-  requestedAt: "2026-01-21 17:00",
-  itemName: "c타입 충전기",
-  itemId: "c타입 충전기 (1)",
-  itemCount: "(2/5)",
-  applicantInfo: {
-    name: "조윤아",
-    major: "동물자원학과",
-    id: "202312690",
-  },
-};
+import { useAdminRentalRequestList } from "../../hooks/queries/useAdminQueries";
 
 const RentalRequestPage = () => {
+  // 관리자 대여 요청 목록 조회
+  const { data, isLoading, error } = useAdminRentalRequestList();
+
+  const requests = data?.requests ?? [];
+
   return (
     <Layout>
       <Header name="건국대학교 도서관자치위원회" pageName="대여요청"></Header>
       <div className="flex flex-col w-full items-center my-8.5 gap-5 overflow-y-auto no-scrollbar">
-        <RentalConfirmCard rental={sampleRental}></RentalConfirmCard>
-        <RentalConfirmCard rental={sampleRental}></RentalConfirmCard>
-        <RentalConfirmCard rental={sampleRental}></RentalConfirmCard>
-        <RentalConfirmCard rental={sampleRental}></RentalConfirmCard>
+        {isLoading && (
+          <p className="text-neutral-gray-3 text-14px">로딩 중...</p>
+        )}
+        {error && (
+          <p className="text-red text-14px">
+            대여 요청 목록을 불러오지 못했습니다.
+          </p>
+        )}
+        {!isLoading && !error && requests.length === 0 && (
+          <p className="pt-50 text-neutral-gray-3 text-14px">
+            대여 요청이 아직 없습니다.
+          </p>
+        )}
+        {!isLoading &&
+          !error &&
+          requests.map((request) => {
+            const rental: RentalRequest = {
+              requestedAt: request.requestedAt,
+              itemName: request.itemName,
+              // 개별 코드형 물품 코드 표시 (예: "C-001")
+              itemId: request.itemUnitCode,
+              // 남은 수량/전체 수량 형식으로 가공
+              itemCount: `(${request.availableQuantity}/${request.totalQuantity})`,
+              applicantInfo: {
+                name: request.borrowerName,
+                major: request.borrowerMajor,
+                id: request.borrowerStudentNumber,
+              },
+            };
+
+            return (
+              <RentalConfirmCard
+                key={request.rentalId}
+                rental={rental}
+              ></RentalConfirmCard>
+            );
+          })}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #57 

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- 대여 요청 페이지 진입 시 대여 요청 목록을 조회하는 API를 연동했습니다.

## ⭐ PR Point (To Reviewer)

## 📷 Screenshot

<img width="708" height="170" alt="image" src="https://github.com/user-attachments/assets/88d30024-6cfb-4c24-943e-4cb09ef0c1c8" />
<img width="503" height="873" alt="image" src="https://github.com/user-attachments/assets/64e5e535-4868-48d5-ac7e-a700272b46a0" />

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자 렌탈 요청 목록 페이지를 동적 데이터로 개선했습니다. 실시간으로 렌탈 요청을 조회하고, 로딩 및 오류 상태를 표시합니다. 페이지네이션 지원으로 대량 데이터를 효율적으로 관리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->