### PR TITLE
[RTR-236] Design: 개인정보 수정 페이지 레이아웃 구현 (API 연동 전)

### DIFF
--- a/public/icons/profile-default-icon.svg
+++ b/public/icons/profile-default-icon.svg
@@ -1,0 +1,38 @@
+<svg width="45" height="58" viewBox="0 0 45 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_2195_18160)">
+<path d="M32.0524 11.2637C31.6087 16.5226 27.0716 20.8126 22.0909 20.8126C17.1101 20.8126 12.5652 16.5236 12.1293 11.2637C11.6765 5.79301 16.0913 1.71484 22.0909 1.71484C28.0904 1.71484 32.5052 5.89248 32.0524 11.2637Z" stroke="url(#paint0_linear_2195_18160)" stroke-width="3.42954" shape-rendering="crispEdges"/>
+</g>
+<g filter="url(#filter1_d_2195_18160)">
+<path d="M39.0374 42.4659C39.0374 47.8345 29.8925 48.6423 22.0909 48.6423C14.2894 48.6423 5.14429 47.84 5.14429 42.4659C5.14429 37.0918 14.2894 28.4922 22.0909 28.4922C29.8925 28.4922 39.0374 37.0973 39.0374 42.4659Z" stroke="url(#paint1_linear_2195_18160)" stroke-width="3.42954" shape-rendering="crispEdges"/>
+</g>
+<defs>
+<filter id="filter0_d_2195_18160" x="6.95205" y="0" width="30.2775" height="29.3864" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42954"/>
+<feGaussianBlur stdDeviation="1.71477"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.66395 0 0 0 0 0.955193 0 0 0 0 1 0 0 0 0.34 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2195_18160"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2195_18160" result="shape"/>
+</filter>
+<filter id="filter1_d_2195_18160" x="-0.000101566" y="26.7773" width="44.1818" height="30.4392" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42954"/>
+<feGaussianBlur stdDeviation="1.71477"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.66395 0 0 0 0 0.955193 0 0 0 0 1 0 0 0 0.34 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2195_18160"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2195_18160" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_2195_18160" x1="31.7246" y1="3.23398" x2="17.2665" y2="9.28463" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CDD6DE"/>
+<stop offset="1" stop-color="#7FB5F7"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2195_18160" x1="38.4273" y1="30.095" x2="18.5902" y2="43.4377" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CDD6DE"/>
+<stop offset="1" stop-color="#7FB5F7"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ModalTestPage } from "./pages/ModalTestPage";
 import LoginPage from "./pages/admin/LoginPage";
 import HomePage from "./pages/admin/HomePage";
 import AccountPage from "./pages/admin/AccountPage";
+import ProfileEditPage from "./pages/admin/ProfileEditPage";
 import LandingPage from "./pages/LandingPage";
 import RegisterPage from "./pages/admin/RegisterPage";
 import TermsConsentPage from "./pages/TermsConsentPage";
@@ -53,6 +54,7 @@ function App() {
         {/* 관리자 홈 페이지 */}
         <Route path="/home" element={<HomePage />} />
         <Route path="/account" element={<AccountPage />} />
+        <Route path="/profile" element={<ProfileEditPage />} />
 
         {/* 대여자 물품 관리 페이지 */}
         <Route path="/item-manage" element={<ItemManagementPage />} />

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -79,7 +79,6 @@ export interface AdminProfileResponse {
 // 5-1. 홈 화면 출력 응답 바디
 export interface LoadHomeResponse {
   organizationId: number; // 관리자 아이디
-  orgId?: number; // 서버 응답 호환용(organizationId 미제공 시 fallback)
   organizationName: string; // 관리자 이름 (단체명)
   profileImageUrl?: string; // 프로필 사진 URL (없는 경우 기본 아이콘 사용됨)
   requestCount: number; // 대여 요청 개수

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -7,6 +7,7 @@ import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
 
 const PRODUCTION_WEB_ORIGIN = "https://www.retrivr.kr";
 const PREVIEW_WEB_ORIGIN = "https://retrivr-web.vercel.app";
+const DEFAULT_PROFILE_IMAGE = "/icons/default-profile.svg";
 
 const getPublicWebOrigin = () => {
   if (typeof window === "undefined") return PREVIEW_WEB_ORIGIN;
@@ -31,7 +32,7 @@ const AccountPage = () => {
   const userProfile = {
     organizationId: data?.organizationId,
     organizationName: data?.organizationName,
-    profileImageUrl: data?.profileImageUrl,
+    profileImageUrl: data?.profileImageUrl ?? "/icons/profile-default-icon.svg",
     email: data?.email,
   };
 
@@ -122,8 +123,12 @@ const AccountPage = () => {
       <div className="w-full font-[Pretendard] text-neutral-gray-1 px-7.75">
         {/* 프로필 영역 - 프로필 사진, 대여지명, 이메일, 개인정보 수정하기 버튼 */}
         <div className="flex flex-col items-center pt-11.5 gap-3.5">
-          <div className="relative w-25 h-25 rounded-[50%] shadow-account-profile">
-            <img src={userProfile.profileImageUrl} alt="프로필 이미지" />
+          <div className="relative flex items-center justify-center w-25 h-25 rounded-[50%] shadow-account-profile">
+            <img
+              className="object-cover"
+              src={userProfile.profileImageUrl}
+              alt="프로필 이미지"
+            />
             <button className="absolute right-0 bottom-0 flex items-center bg-neutral-white justify-center w-7 h-7 rounded-[50%] shadow-camera cursor-pointer">
               <img src="/icons/camera.svg" alt="프로필 이미지 변경하기" />
             </button>

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -7,7 +7,6 @@ import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
 
 const PRODUCTION_WEB_ORIGIN = "https://www.retrivr.kr";
 const PREVIEW_WEB_ORIGIN = "https://retrivr-web.vercel.app";
-const DEFAULT_PROFILE_IMAGE = "/icons/default-profile.svg";
 
 const getPublicWebOrigin = () => {
   if (typeof window === "undefined") return PREVIEW_WEB_ORIGIN;

--- a/src/pages/admin/HomePage.tsx
+++ b/src/pages/admin/HomePage.tsx
@@ -38,7 +38,7 @@ const Home = () => {
   // 임시: API 연동 전까지 빈 배열과 0 사용
 
   const UserProfile = {
-    organizationId: data?.organizationId ?? data?.orgId, // 관리자 ID
+    organizationId: data?.organizationId, // 관리자 ID
     organizationName: data?.organizationName, // 관리자 이름 (단체명)
     profileImageUrl: data?.profileImageUrl, // 프로필 사진 URL
     requestCount: data?.requestCount ?? 0, // 대여 요청 개수

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { Layout } from "../../components/Layout";
+import Header from "../../components/Header";
+import CommonInput from "../../components/CommonInput";
+import Button from "../../components/Button";
+
+const ProfileEditPage = () => {
+  const [organizationName, setOrganizationName] = useState("");
+  const [email, setEmail] = useState("");
+  const [authCode, setAuthCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordCheck, setPasswordCheck] = useState("");
+  const [adminCode, setAdminCode] = useState("");
+
+  return (
+    <Layout>
+      <Header pageName="개인정보 수정" backTo="/account" />
+      <div className="flex flex-col items-center w-full gap-6 pt-8 px-8 ">
+        {/* 1. 이름(단체명) 입력필드 */}
+        <div className="flex flex-col w-full gap-2">
+          <div className="flex gap-0.5">
+            <p className=" text-14px font-bold">이름(단체명)</p>
+            <p className="text-14px text-primary">*</p>
+          </div>
+          <CommonInput
+            type="text"
+            value={organizationName}
+            onChange={(e) => setOrganizationName(e.target.value)}
+            placeholder="한국대 도서관자치위원회"
+            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+          />
+        </div>
+
+        {/* 2. 이메일 인증 관련 입력 필드 */}
+        <div className="flex flex-col w-full gap-2.5">
+          <div className="flex gap-0.5">
+            <p className=" text-14px font-bold ">이메일</p>
+            <p className="text-14px text-primary">*</p>
+          </div>
+          <div className="flex justify-between items-center gap-1">
+            <CommonInput
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="retrivr@gmail.com"
+              className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+            />
+            <Button variant="primary" size="sm" className="w-25 h-11.5">
+              인증번호 전송
+            </Button>
+          </div>
+          <div className="relative flex justify-between items-center gap-1">
+            <CommonInput
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]{6}"
+              maxLength={6}
+              value={authCode}
+              onChange={(e) => setAuthCode(e.target.value)}
+              placeholder="인증번호 입력"
+              className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+            />
+
+            <Button variant="gray" size="sm" className="w-25 h-11.5">
+              인증번호 확인
+            </Button>
+          </div>
+        </div>
+
+        {/* 3. 비밀번호/비밀번호 확인 입력 필드 */}
+        <div className="flex flex-col w-full gap-1.5">
+          <div className="flex gap-0.5">
+            <p className="text-14px font-bold">비밀번호</p>
+            <p className="text-14px text-primary font-bold">*</p>
+          </div>
+          <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[130%]">
+            영문자, 숫자, 특수문자를 포함한 8자 이상으로 설정해주세요.
+          </p>
+          <CommonInput
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호 입력"
+            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+          />
+        </div>
+
+        <div className="flex flex-col w-full gap-2.5">
+          <div className="flex gap-0.5">
+            <p className="text-14px font-bold">비밀번호 확인</p>
+            <p className="text-14px text-primary">*</p>
+          </div>
+          <CommonInput
+            type="password"
+            value={passwordCheck}
+            onChange={(e) => setPasswordCheck(e.target.value)}
+            placeholder="비밀번호 재입력"
+            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+          />
+        </div>
+
+        {/* 4. 관리자 코드 입력 필드 */}
+        <div className="flex flex-col w-full gap-1.5">
+          <div className="flex gap-0.5">
+            <p className=" text-14px font-bold">관리자 코드</p>
+            <p className=" text-14px text-primary">*</p>
+          </div>
+          <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[140%]">
+            물품 관리 등 중요할 때 쓰이는 코드로, 숫자만 입력 가능해요.
+          </p>
+          <CommonInput
+            value={adminCode}
+            onChange={(e) => setAdminCode(e.target.value)}
+            placeholder="관리자 코드 입력"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            maxLength={6}
+            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+          />
+        </div>
+      </div>
+
+      {/* 5. 확인 버튼 */}
+      <div className="w-full flex flex-col items-center mt-auto mb-10">
+        <Button variant="primary" size="lg">
+          확인
+        </Button>
+      </div>
+    </Layout>
+  );
+};
+
+export default ProfileEditPage;


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- 개인정보 수정 페이지 레이아웃 구현 완료했습니다.
- 계정 관리 페이지에서 '개인정보 수정하기' 버튼 클릭 시 해당 페이지로 넘어올 수 있으나, 아직 관리자 코드 인증 API 연동 전이라 버튼에 이벤트 추가는 안한 상황입니다.
- 아직 관련 API(이메일 검증, 비밀번호 변경, 개인정보 수정) 연동 전입니다. 
 
## ⭐ PR Point (To Reviewer)

- 없습니다.

## 📷 Screenshot

<img width="472" height="927" alt="image" src="https://github.com/user-attachments/assets/cd20437b-386d-4552-b623-10b3ca558e56" />

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 관리자 프로필 편집 페이지 추가: 조직명, 이메일, 비밀번호, 인증 코드 관리 가능

* **버그 수정**
  * 프로필 이미지 표시 개선: 이미지 누락 시 기본 아이콘 표시 및 레이아웃 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->