### PR TITLE
Edit: 대여 정보 입력 페이지 동의 카드 숨김 조건 추가

### DIFF
--- a/src/components/cards/client/RentalAvailableItemCard.tsx
+++ b/src/components/cards/client/RentalAvailableItemCard.tsx
@@ -6,8 +6,6 @@ import Button from "../../Button";
 import { requestItemDetail } from "../../../api/client/client.api";
 import CustomCheckBox from "../../CustomCheckbox";
 
-const CLIENT_TERMS_REDIRECT_STORAGE_KEY = "clientTermsRedirectPayload";
-
 interface RentalAvailableItemCardProps {
   itemInfo: ItemRequest;
   organizationId: number;
@@ -76,19 +74,7 @@ const RentalAvailableItemCard = ({
       description: item.description,
       borrowerRequirements,
     };
-
-    const termsRedirectPayload = {
-      userType: "client" as const,
-      nextPath: "/client-rental-information-submit",
-      nextState: rentalFormState,
-    };
-
-    sessionStorage.setItem(
-      CLIENT_TERMS_REDIRECT_STORAGE_KEY,
-      JSON.stringify(termsRedirectPayload),
-    );
-
-    navigate("/terms", { state: termsRedirectPayload });
+    navigate("/client-rental-information-submit", { state: rentalFormState });
   };
 
   return (

--- a/src/pages/TermsConsentPage.tsx
+++ b/src/pages/TermsConsentPage.tsx
@@ -19,6 +19,11 @@ type TermsRouteState = {
   nextState?: unknown;
 };
 
+const PAGE_DESTINATION_BY_USER_TYPE: Record<"admin" | "client", string> = {
+  admin: "/login",
+  client: "/",
+};
+
 const TERMS_CONTENT_BY_USER_TYPE: Record<"admin" | "client", string> = {
   admin: `제1조 (목적)
 본 약관은 Retrivr가 제공하는 관리자용 서비스 이용과 관련된 조건 및 절차를 규정함을 목적으로 합니다.
@@ -283,7 +288,10 @@ const TermsConsentPage = () => {
   return (
     <Layout>
       {/* 헤더 영역 - 페이지 제목 + 뒤로가기 */}
-      <Header pageName="이용 약관 동의" backTo="/login" />
+      <Header
+        pageName="이용 약관 동의"
+        backTo={PAGE_DESTINATION_BY_USER_TYPE[userType]}
+      />
 
       {/* 본문 영역 - 필수 약관 동의 2개 + 모두 동의 체크 */}
       <div className="flex w-full flex-col gap-7.5 px-8 pt-10 font-[Pretendard]">

--- a/src/pages/client/RentalInformationSubmitPage.tsx
+++ b/src/pages/client/RentalInformationSubmitPage.tsx
@@ -465,13 +465,15 @@ const RentalInformationSubmitPage = () => {
                 checked={firstConsentChecked}
                 onCheckedChange={setFirstConsentChecked}
               />
-              {guaranteedGoods != "" && guaranteedGoods != "-" && (
-                <ConsentSectionCard
-                  label={label2 + guaranteedGoods + label3}
-                  checked={secondConsentChecked}
-                  onCheckedChange={setSecondConsentChecked}
-                />
-              )}
+              {guaranteedGoods != "" &&
+                guaranteedGoods != "없음" &&
+                guaranteedGoods != "-" && (
+                  <ConsentSectionCard
+                    label={label2 + guaranteedGoods + label3}
+                    checked={secondConsentChecked}
+                    onCheckedChange={setSecondConsentChecked}
+                  />
+                )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

<!-- 작업한 내용을 작성해주세요 -->

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 임차인 정보 제출 페이지에서 동의 카드의 표시 조건을 개선했습니다. 담보 물품이 "없음"으로 표시된 경우 관련 동의 카드가 더 이상 나타나지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->