### PR TITLE
[RTR-252] 라우팅 히스토리 처리방식 변경 및 회원가입 페이지 & 프로필 수정 페이지 입력 필드 컴포넌트화 + 비밀번호 입력규칙 변경

### DIFF
--- a/src/components/admin/AdminAccountCommonFields.tsx
+++ b/src/components/admin/AdminAccountCommonFields.tsx
@@ -1,0 +1,146 @@
+import CommonInput from "../CommonInput";
+
+type Variant = "register" | "profileEdit";
+
+type AdminAccountCommonFieldsProps = {
+  variant: Variant;
+  includeOrganizationName?: boolean;
+  organizationName: string;
+  onOrganizationNameChange: (value: string) => void;
+  password: string;
+  onPasswordChange: (value: string) => void;
+  passwordCheck: string;
+  onPasswordCheckChange: (value: string) => void;
+  adminCode: string;
+  onAdminCodeChange: (value: string) => void;
+};
+
+const AdminAccountCommonFields = ({
+  variant,
+  includeOrganizationName = true,
+  organizationName,
+  onOrganizationNameChange,
+  password,
+  onPasswordChange,
+  passwordCheck,
+  onPasswordCheckChange,
+  adminCode,
+  onAdminCodeChange,
+}: AdminAccountCommonFieldsProps) => {
+  const isRegister = variant === "register";
+
+  return (
+    <>
+      {includeOrganizationName && (
+        <div className="flex flex-col w-full gap-2">
+          <div>
+            <p className="inline text-[0.875rem] font-bold leading-none">
+              이름(단체명)
+            </p>
+            <p className="inline text-primary">*</p>
+          </div>
+          {isRegister && (
+            <p className="text-neutral-3 text-[0.75rem] font-normal leading-none">
+              공식 명칭을 사용해주세요. ex)리턴즈(X), 00학생회(O)
+            </p>
+          )}
+          <CommonInput
+            type="text"
+            value={organizationName}
+            onChange={(e) => onOrganizationNameChange(e.target.value)}
+            placeholder={
+              isRegister ? "한국대 학생회" : "한국대 도서관자치위원회"
+            }
+            className={
+              isRegister
+                ? undefined
+                : "placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+            }
+          />
+        </div>
+      )}
+
+      {/* 비밀번호 영역 */}
+      <div
+        className={`flex flex-col w-full ${isRegister ? "gap-2" : "gap-1.5"}`}
+      >
+        <div className="flex gap-0.5">
+          <p className="text-14px font-bold">비밀번호</p>
+          <p className="text-14px text-primary font-bold">*</p>
+        </div>
+        {!isRegister && (
+          <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[130%]">
+            영문자(대문자/소문자), 숫자, 특수문자를 포함한 8자 이상으로
+            설정해주세요. 특수문자는 !@#$%^&*만 사용할 수 있어요.
+          </p>
+        )}
+        <CommonInput
+          value={password}
+          onChange={(e) => onPasswordChange(e.target.value)}
+          type="password"
+          placeholder="비밀번호 입력"
+          className={
+            isRegister
+              ? undefined
+              : "placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+          }
+        />
+      </div>
+
+      {/* 비밀번호 확인 영역 */}
+      <div
+        className={`flex flex-col w-full ${isRegister ? "gap-2" : "gap-2.5"}`}
+      >
+        <div className="flex gap-0.5">
+          <p className="text-14px font-bold">비밀번호 확인</p>
+          <p className="text-14px text-primary">*</p>
+        </div>
+        <CommonInput
+          value={passwordCheck}
+          onChange={(e) => onPasswordCheckChange(e.target.value)}
+          type="password"
+          placeholder="비밀번호 재입력"
+          className={
+            isRegister
+              ? undefined
+              : "placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+          }
+        />
+      </div>
+
+      {/* 관리자 코드 영역 */}
+      <div
+        className={`flex flex-col w-full ${isRegister ? "gap-2" : "gap-1.5"}`}
+      >
+        <div className="flex gap-0.5">
+          <p className="text-14px font-bold">관리자 코드</p>
+          <p className="text-14px text-primary">*</p>
+        </div>
+        <p
+          className={
+            isRegister
+              ? "text-neutral-3 text-[0.75rem] font-normal leading-none"
+              : "pb-1 text-neutral-gray-3 text-12px font-normal leading-[140%]"
+          }
+        >
+          물품 관리 등 중요할 때 쓰이는 코드로, 숫자만 입력 가능해요.
+        </p>
+        <CommonInput
+          value={adminCode}
+          onChange={(e) => onAdminCodeChange(e.target.value)}
+          placeholder={isRegister ? "010101" : "관리자 코드 입력"}
+          inputMode="numeric"
+          pattern="[0-9]*"
+          maxLength={6}
+          className={
+            isRegister
+              ? undefined
+              : "placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+          }
+        />
+      </div>
+    </>
+  );
+};
+
+export default AdminAccountCommonFields;

--- a/src/components/admin/AdminAccountCommonFields.tsx
+++ b/src/components/admin/AdminAccountCommonFields.tsx
@@ -68,12 +68,12 @@ const AdminAccountCommonFields = ({
           <p className="text-14px font-bold">비밀번호</p>
           <p className="text-14px text-primary font-bold">*</p>
         </div>
-        {!isRegister && (
-          <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[130%]">
-            영문자(대문자/소문자), 숫자, 특수문자를 포함한 8자 이상으로
-            설정해주세요. 특수문자는 !@#$%^&*만 사용할 수 있어요.
-          </p>
-        )}
+
+        <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[130%]">
+          영문자(대문자/소문자), 숫자, 특수문자를 포함한 8자 이상으로
+          설정해주세요. 특수문자는 !@#$%^&*만 사용할 수 있어요.
+        </p>
+
         <CommonInput
           value={password}
           onChange={(e) => onPasswordChange(e.target.value)}

--- a/src/pages/admin/AdminItemFormPage.tsx
+++ b/src/pages/admin/AdminItemFormPage.tsx
@@ -778,9 +778,7 @@ const AdminItemFormPage = ({
                 : "물품 정보가 수정되었습니다."
             }
             confirmText="확인하기"
-            onConfirm={() =>
-              navigate("/item-manage", { replace: mode === "create" })
-            }
+            onConfirm={() => navigate("/item-manage", { replace: true })}
           />
         )}
 

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -3,6 +3,8 @@ import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import CommonInput from "../../components/CommonInput";
 import Button from "../../components/Button";
+import { getPasswordValidationError } from "../../utils/passwordValidation";
+import AdminAccountCommonFields from "../../components/admin/AdminAccountCommonFields";
 
 const ProfileEditPage = () => {
   const [organizationName, setOrganizationName] = useState("");
@@ -11,6 +13,26 @@ const ProfileEditPage = () => {
   const [password, setPassword] = useState("");
   const [passwordCheck, setPasswordCheck] = useState("");
   const [adminCode, setAdminCode] = useState("");
+
+  const handleSubmit = () => {
+    if (!organizationName.trim()) return alert("이름(단체명)을 입력해주세요.");
+    if (!email.trim()) return alert("이메일을 입력해주세요.");
+
+    const passwordError = getPasswordValidationError(password);
+    if (passwordError) return alert(passwordError);
+
+    if (!passwordCheck) return alert("비밀번호 확인 입력을 진행해주세요.");
+    if (password !== passwordCheck) {
+      return alert("비밀번호가 일치하지 않습니다. 다시 입력해주세요.");
+    }
+
+    if (!adminCode.trim()) return alert("관리자 코드를 입력해주세요.");
+    if (!/^\d{6}$/.test(adminCode)) {
+      return alert("관리자 코드는 6자리 숫자여야 합니다.");
+    }
+
+    alert("입력값 검증이 완료되었습니다.");
+  };
 
   return (
     <Layout>
@@ -67,62 +89,23 @@ const ProfileEditPage = () => {
           </div>
         </div>
 
-        {/* 3. 비밀번호/비밀번호 확인 입력 필드 */}
-        <div className="flex flex-col w-full gap-1.5">
-          <div className="flex gap-0.5">
-            <p className="text-14px font-bold">비밀번호</p>
-            <p className="text-14px text-primary font-bold">*</p>
-          </div>
-          <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[130%]">
-            영문자, 숫자, 특수문자를 포함한 8자 이상으로 설정해주세요.
-          </p>
-          <CommonInput
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="비밀번호 입력"
-            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
-          />
-        </div>
-
-        <div className="flex flex-col w-full gap-2.5">
-          <div className="flex gap-0.5">
-            <p className="text-14px font-bold">비밀번호 확인</p>
-            <p className="text-14px text-primary">*</p>
-          </div>
-          <CommonInput
-            type="password"
-            value={passwordCheck}
-            onChange={(e) => setPasswordCheck(e.target.value)}
-            placeholder="비밀번호 재입력"
-            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
-          />
-        </div>
-
-        {/* 4. 관리자 코드 입력 필드 */}
-        <div className="flex flex-col w-full gap-1.5">
-          <div className="flex gap-0.5">
-            <p className=" text-14px font-bold">관리자 코드</p>
-            <p className=" text-14px text-primary">*</p>
-          </div>
-          <p className="pb-1 text-neutral-gray-3 text-12px font-normal leading-[140%]">
-            물품 관리 등 중요할 때 쓰이는 코드로, 숫자만 입력 가능해요.
-          </p>
-          <CommonInput
-            value={adminCode}
-            onChange={(e) => setAdminCode(e.target.value)}
-            placeholder="관리자 코드 입력"
-            inputMode="numeric"
-            pattern="[0-9]*"
-            maxLength={6}
-            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
-          />
-        </div>
+        <AdminAccountCommonFields
+          variant="profileEdit"
+          includeOrganizationName={false}
+          organizationName={organizationName}
+          onOrganizationNameChange={setOrganizationName}
+          password={password}
+          onPasswordChange={setPassword}
+          passwordCheck={passwordCheck}
+          onPasswordCheckChange={setPasswordCheck}
+          adminCode={adminCode}
+          onAdminCodeChange={setAdminCode}
+        />
       </div>
 
       {/* 5. 확인 버튼 */}
       <div className="w-full flex flex-col items-center mt-auto mb-10">
-        <Button variant="primary" size="lg">
+        <Button variant="primary" size="lg" onClick={handleSubmit}>
           확인
         </Button>
       </div>

--- a/src/pages/admin/RegisterPage.tsx
+++ b/src/pages/admin/RegisterPage.tsx
@@ -11,14 +11,8 @@ import CommonInput from "../../components/CommonInput";
 import Button from "../../components/Button";
 import ConfirmModal from "../../components/modals/ConfirmModal";
 import ErrorModal from "../../components/modals/ErrorModal";
-
-// 비밀번호 입력규칙 : 소문자 + 숫자 + 특수문자 각 1개씩 포함하여 8자 이상
-const PASSWORD_MIN_LENGTH = 8;
-const PASSWORD_ALLOWED_SPECIALS = "!@#$%^&*";
-const PASSWORD_ALLOWED_PATTERN = /^[a-z0-9!@#$%^&*]+$/;
-const PASSWORD_LOWERCASE_PATTERN = /[a-z]/;
-const PASSWORD_NUMBER_PATTERN = /\d/;
-const PASSWORD_SPECIAL_PATTERN = /[!@#$%^&*]/;
+import { getPasswordValidationError } from "../../utils/passwordValidation";
+import AdminAccountCommonFields from "../../components/admin/AdminAccountCommonFields";
 
 // 관리자 회원가입 페이지
 const RegisterPage = () => {
@@ -140,26 +134,8 @@ const RegisterPage = () => {
   const handleRequestRegisteration = () => {
     if (!organizationName.trim()) return alert("이름(단체명)을 입력해주세요.");
     if (!isVerified) return alert("이메일 인증을 진행해주세요.");
-    if (!password) return alert("비밀번호를 입력해주세요.");
-    if (password.length < PASSWORD_MIN_LENGTH) {
-      return alert("비밀번호는 8자 이상이어야 합니다.");
-    }
-    if (!PASSWORD_LOWERCASE_PATTERN.test(password)) {
-      return alert("비밀번호에 소문자를 최소 1개 이상 포함해주세요.");
-    }
-    if (!PASSWORD_NUMBER_PATTERN.test(password)) {
-      return alert("비밀번호에 숫자를 최소 1개 이상 포함해주세요.");
-    }
-    if (!PASSWORD_SPECIAL_PATTERN.test(password)) {
-      return alert(
-        `비밀번호에 특수문자를 최소 1개 이상 포함해주세요. (${PASSWORD_ALLOWED_SPECIALS})`,
-      );
-    }
-    if (!PASSWORD_ALLOWED_PATTERN.test(password)) {
-      return alert(
-        `비밀번호는 소문자, 숫자, 특수문자 ${PASSWORD_ALLOWED_SPECIALS}만 사용할 수 있습니다.`,
-      );
-    }
+    const passwordError = getPasswordValidationError(password);
+    if (passwordError) return alert(passwordError);
     if (!passwordChecked) return alert("비밀번호 확인 입력을 진행해주세요.");
     if (!isPasswordSame)
       return alert("비밀번호가 일치하지 않습니다. 다시 입력해주세요.");
@@ -296,55 +272,18 @@ const RegisterPage = () => {
             </Button>
           </div>
         </div>
-        {/* 비밀번호 영역 */}
-        <div className="flex flex-col w-full gap-2">
-          <div>
-            <p className="inline text-[0.875rem] font-bold leading-none">
-              비밀번호
-            </p>
-            <p className="inline text-primary leading-none">*</p>
-          </div>
-          <CommonInput
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            type="password"
-            placeholder="비밀번호 입력"
-          ></CommonInput>
-        </div>
-        {/* 비밀번호 확인 영역 */}
-        <div className="flex flex-col w-full gap-2">
-          <div>
-            <p className="inline text-[0.875rem] font-bold leading-none">
-              비밀번호 확인
-            </p>
-            <p className="inline text-primary leading-none">*</p>
-          </div>
-          <CommonInput
-            value={passwordChecked}
-            onChange={(e) => setPasswordChecked(e.target.value)}
-            type="password"
-            placeholder="비밀번호 재입력"
-          ></CommonInput>
-        </div>
-        {/* 관리자 코드 영역*/}
-        <div className="flex flex-col w-full gap-2">
-          <div>
-            <p className="inline text-[0.875rem] font-bold leading-none">
-              관리자 코드
-            </p>
-            <p className="inline text-primary leading-none">*</p>
-          </div>
-          <p className="text-neutral-3 text-[0.75rem] font-normal leading-none">
-            물품 관리 등 중요할 때 쓰이는 코드로, 숫자만 입력 가능해요.
-          </p>
-          <CommonInput
-            value={adminCode}
-            onChange={(e) => setAdminCode(e.target.value)}
-            placeholder="010101"
-            pattern="[0-9]*"
-            maxLength={6}
-          ></CommonInput>
-        </div>
+        <AdminAccountCommonFields
+          variant="register"
+          includeOrganizationName={false}
+          organizationName={organizationName}
+          onOrganizationNameChange={setOrganizationName}
+          password={password}
+          onPasswordChange={setPassword}
+          passwordCheck={passwordChecked}
+          onPasswordCheckChange={setPasswordChecked}
+          adminCode={adminCode}
+          onAdminCodeChange={setAdminCode}
+        />
       </div>
       <div className="w-full flex flex-col items-center mt-14.5 mb-10">
         <Button

--- a/src/pages/client/RentalConfirmationPage.tsx
+++ b/src/pages/client/RentalConfirmationPage.tsx
@@ -23,10 +23,12 @@ const RentalConfirmationPage = () => {
   // organizationId가 유효하면 해당 대여지 홈으로, 없으면 검색 페이지로 이동함
   const handleConfirmClick = () => {
     if (Number.isFinite(organizationId) && organizationId > 0) {
-      navigate(`/client-home?organizationId=${organizationId}`);
+      navigate(`/client-home?organizationId=${organizationId}`, {
+        replace: true,
+      });
       return;
     }
-    navigate("/client-search");
+    navigate("/client-search", { replace: true });
   };
 
   const handleOpenAdminCodeModal = () => {

--- a/src/pages/client/RentalInformationSubmitPage.tsx
+++ b/src/pages/client/RentalInformationSubmitPage.tsx
@@ -297,6 +297,7 @@ const RentalInformationSubmitPage = () => {
           if (organizationId && organizationId > 0) {
             navigate(
               `/client-rental-confirmation?organizationId=${organizationId}${rentalIdQuery}`,
+              { replace: true },
             );
             return;
           }
@@ -304,6 +305,7 @@ const RentalInformationSubmitPage = () => {
             rentalIdQuery
               ? `/client-rental-confirmation?${rentalIdQuery.slice(1)}`
               : "/client-rental-confirmation",
+            { replace: true },
           );
         },
         onError: () => {

--- a/src/utils/passwordValidation.ts
+++ b/src/utils/passwordValidation.ts
@@ -1,0 +1,28 @@
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_ALLOWED_SPECIALS = "!@#$%^&*";
+export const PASSWORD_ALLOWED_PATTERN = /^[A-Za-z0-9!@#$%^&*]+$/;
+export const PASSWORD_LETTER_PATTERN = /[A-Za-z]/;
+export const PASSWORD_NUMBER_PATTERN = /\d/;
+export const PASSWORD_SPECIAL_PATTERN = /[!@#$%^&*]/;
+
+export const getPasswordValidationError = (
+  password: string,
+): string | null => {
+  if (!password) return "비밀번호를 입력해주세요.";
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return "비밀번호는 8자 이상이어야 합니다.";
+  }
+  if (!PASSWORD_LETTER_PATTERN.test(password)) {
+    return "비밀번호에 영문자(대문자 또는 소문자)를 최소 1개 이상 포함해주세요.";
+  }
+  if (!PASSWORD_NUMBER_PATTERN.test(password)) {
+    return "비밀번호에 숫자를 최소 1개 이상 포함해주세요.";
+  }
+  if (!PASSWORD_SPECIAL_PATTERN.test(password)) {
+    return `비밀번호에 특수문자를 최소 1개 이상 포함해주세요. (${PASSWORD_ALLOWED_SPECIALS})`;
+  }
+  if (!PASSWORD_ALLOWED_PATTERN.test(password)) {
+    return `비밀번호는 영문자(대문자/소문자), 숫자, 특수문자 ${PASSWORD_ALLOWED_SPECIALS}만 사용할 수 있습니다.`;
+  }
+  return null;
+};

--- a/src/utils/passwordValidation.ts
+++ b/src/utils/passwordValidation.ts
@@ -5,9 +5,7 @@ export const PASSWORD_LETTER_PATTERN = /[A-Za-z]/;
 export const PASSWORD_NUMBER_PATTERN = /\d/;
 export const PASSWORD_SPECIAL_PATTERN = /[!@#$%^&*]/;
 
-export const getPasswordValidationError = (
-  password: string,
-): string | null => {
+export const getPasswordValidationError = (password: string): string | null => {
   if (!password) return "비밀번호를 입력해주세요.";
   if (password.length < PASSWORD_MIN_LENGTH) {
     return "비밀번호는 8자 이상이어야 합니다.";
@@ -18,11 +16,11 @@ export const getPasswordValidationError = (
   if (!PASSWORD_NUMBER_PATTERN.test(password)) {
     return "비밀번호에 숫자를 최소 1개 이상 포함해주세요.";
   }
-  if (!PASSWORD_SPECIAL_PATTERN.test(password)) {
-    return `비밀번호에 특수문자를 최소 1개 이상 포함해주세요. (${PASSWORD_ALLOWED_SPECIALS})`;
-  }
   if (!PASSWORD_ALLOWED_PATTERN.test(password)) {
     return `비밀번호는 영문자(대문자/소문자), 숫자, 특수문자 ${PASSWORD_ALLOWED_SPECIALS}만 사용할 수 있습니다.`;
+  }
+  if (!PASSWORD_SPECIAL_PATTERN.test(password)) {
+    return `비밀번호에 특수문자를 최소 1개 이상 포함해주세요. (${PASSWORD_ALLOWED_SPECIALS})`;
   }
   return null;
 };


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- 다수의 물품 등록 후 헤더를 통한 뒤로가기가 아닌, 브라우저 스와이프를 통해 뒤로가기를 진행하면 수 차례 등록했던 물품등록 페이지가 나오는 것을 방지하고자 코드 수정했습니다.
- 기존 라우터 히스토리를 push로 처리하고 있었는데, 일부 페이지는 replace로 변경하여 불필요한 접근 방지했습니다.

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

## 🔔 ETC

[<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
](https://velog.io/@gwak2837/React-Router-History-push%EC%99%80-replace%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 검증이 모든 관리자 페이지에서 일관되게 적용됩니다.
  * 관리자 계정 등록 및 프로필 편집 폼 필드가 통합되었습니다.

* **개선사항**
  * 렌탈 확인, 제출, 관리 항목 폼 페이지의 페이지 전환 동작이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->