### PR TITLE
Fix: GA4 동의 여부 관리자/대여자 로 분리 및 대여자 이용 약관 동의 페이지 진입 시점 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,11 +26,22 @@ import ClientHomePage from "./pages/client/ClientHomePage";
 import RentalInformationSubmitPage from "./pages/client/RentalInformationSubmitPage";
 import RenterSearchPage from "./pages/client/RenterSearchPage";
 import RentalConfirmationPage from "./pages/client/RentalConfirmationPage";
-import { GA_CONSENT_STORAGE_KEY, trackPageView } from "./lib/analytics";
+import {
+  ADMIN_GA_CONSENT_STORAGE_KEY,
+  CLIENT_GA_CONSENT_STORAGE_KEY,
+  trackPageView,
+} from "./lib/analytics";
 
-const hasTermsConsent = () =>
-  typeof window !== "undefined" &&
-  localStorage.getItem(GA_CONSENT_STORAGE_KEY) === "true";
+type UserType = "admin" | "client";
+
+const hasTermsConsent = (userType: UserType) => {
+  if (typeof window === "undefined") return false;
+  const consentKey =
+    userType === "client"
+      ? CLIENT_GA_CONSENT_STORAGE_KEY
+      : ADMIN_GA_CONSENT_STORAGE_KEY;
+  return localStorage.getItem(consentKey) === "true";
+};
 
 const isAuthenticated = () =>
   typeof window !== "undefined" && Boolean(localStorage.getItem("accessToken"));
@@ -47,12 +58,22 @@ const RouteChangeTracker = () => {
 
 const TermsGate = () => {
   const location = useLocation();
+  const userType: UserType = location.pathname.startsWith("/client")
+    ? "client"
+    : "admin";
 
-  // 이미 로그인된 세션은 `/home` 등으로 진입할 때 `/terms`로 되돌리지 않음.
-  if (hasTermsConsent() || isAuthenticated()) return <Outlet />;
+  // client 플로우는 accessToken과 무관하게 client 약관 동의 여부로만 판단.
+  if (userType === "client" && hasTermsConsent("client")) return <Outlet />;
+
+  // admin 플로우는 관리자 약관 동의 또는 로그인 세션이 있으면 통과.
+  if (
+    userType === "admin" &&
+    (hasTermsConsent("admin") || isAuthenticated())
+  ) {
+    return <Outlet />;
+  }
 
   const nextPath = `${location.pathname}${location.search}`;
-  const userType = location.pathname.startsWith("/client") ? "client" : "admin";
   const nextState = location.state;
 
   return (
@@ -102,19 +123,19 @@ function App() {
             path="/client-rental-information-submit"
             element={<RentalInformationSubmitPage />}
           />
+        </Route>
 
-          {/* Auth-required */}
-          <Route element={<AuthGate />}>
-            <Route path="/home" element={<HomePage />} />
-            <Route path="/account" element={<AccountPage />} />
-            <Route path="/profile" element={<ProfileEditPage />} />
-            <Route path="/item-manage" element={<ItemManagementPage />} />
-            <Route path="/item-register" element={<ItemRegisterationPage />} />
-            <Route path="/item-edit/:itemId" element={<ItemEditPage />} />
-            <Route path="/return-manage" element={<ReturnManagementPage />} />
-            <Route path="/return-check/:itemId" element={<ReturnCheckPage />} />
-            <Route path="/rental-request" element={<RentalRequestPage />} />
-          </Route>
+        {/* Auth-required */}
+        <Route element={<AuthGate />}>
+          <Route path="/home" element={<HomePage />} />
+          <Route path="/account" element={<AccountPage />} />
+          <Route path="/profile" element={<ProfileEditPage />} />
+          <Route path="/item-manage" element={<ItemManagementPage />} />
+          <Route path="/item-register" element={<ItemRegisterationPage />} />
+          <Route path="/item-edit/:itemId" element={<ItemEditPage />} />
+          <Route path="/return-manage" element={<ReturnManagementPage />} />
+          <Route path="/return-check/:itemId" element={<ReturnCheckPage />} />
+          <Route path="/rental-request" element={<RentalRequestPage />} />
         </Route>
 
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/api/client/client.type.ts
+++ b/src/api/client/client.type.ts
@@ -64,11 +64,14 @@ export interface BorrowerInformationResponse {
 export interface RentalDetailResponse {
   rentalId: number;
   itemName: string;
+  rentalDuration: number; // 대여 일수
   itemUnitLabel?: string;
+  contact?: string; // 대여자 연락처
+  guaranteedGoods?: string; // 보증 물품
   borrowerField?: Record<string, string>;
   // 일부 응답에서는 borrowerField와 별도로 연락처가 루트에 포함되기도 함
-  contact?: string;
-  requestedAt: string;
+  requestNote?: string; // 대여자 요청사항
+  requestedAt: string; // 대여자 요청 시각
 }
 
 // 3. 대여지 검색

--- a/src/components/cards/admin/rental/RentRequestCard.tsx
+++ b/src/components/cards/admin/rental/RentRequestCard.tsx
@@ -51,7 +51,7 @@ export const RentRequestCard = ({
         applicant={applicant}
         time={time}
         rentalDurationDays={rentalDuration}
-        guaranteedGoods={guaranteedGoods}
+        guaranteedGoodsProp={guaranteedGoods}
         itemUnitLabel={itemUnitLabel}
       />
     </>

--- a/src/components/modals/admin/rentalApprovalModal/LongRentalApprovalModal.tsx
+++ b/src/components/modals/admin/rentalApprovalModal/LongRentalApprovalModal.tsx
@@ -24,7 +24,7 @@ interface LongRentalApproveModalProps {
   contact?: string;
   time?: string;
   rentalDurationDays?: number;
-  guaranteedGoods?: string;
+  guaranteedGoodsProp?: string;
 }
 
 const LongRentalApprovalModal = ({
@@ -40,7 +40,7 @@ const LongRentalApprovalModal = ({
   contact: contactProp,
   time: timeProp,
   rentalDurationDays,
-  guaranteedGoods,
+  guaranteedGoodsProp,
 }: LongRentalApproveModalProps) => {
   const navigate = useNavigate();
   const [isGuaranteedChecked, setIsGuaranteedChecked] = useState(false);
@@ -77,7 +77,8 @@ const LongRentalApprovalModal = ({
   const count = rentalDetail?.itemUnitLabel
     ? `(${rentalDetail.itemUnitLabel})`
     : countProp;
-
+  const rentalDuration = rentalDetail?.rentalDuration ?? rentalDurationDays;
+  const guaranteedGoods = rentalDetail?.guaranteedGoods ?? guaranteedGoodsProp;
   const contactFromBorrowerField = useMemo(() => {
     const field = rentalDetail?.borrowerField;
     if (!field) return { key: undefined as string | undefined, value: "" };
@@ -98,6 +99,22 @@ const LongRentalApprovalModal = ({
       keyPatterns.some((pattern) => pattern.test(k)),
     );
     return { key: matched?.[0], value: matched?.[1] ?? "" };
+  }, [rentalDetail?.borrowerField]);
+
+  const borrowerFieldNameOnly = useMemo(() => {
+    const field = rentalDetail?.borrowerField;
+    if (!field) return "";
+
+    const entries = Object.entries(field)
+      .filter(([, v]) => typeof v === "string" && v.trim().length > 0)
+      .map(([k, v]) => [String(k), v] as const);
+
+    const keyPatterns: RegExp[] = [/이름/i, /^name$/i];
+
+    const matched = entries.find(([k]) =>
+      keyPatterns.some((pattern) => pattern.test(k)),
+    );
+    return (matched?.[1] ?? "").trim();
   }, [rentalDetail?.borrowerField]);
 
   // admin(HomePage) 흐름에서는 `applicant`에 "이름 | 연락처"가 함께 들어오는 경우가 있어,
@@ -133,22 +150,15 @@ const LongRentalApprovalModal = ({
 
   const applicant = useMemo(() => {
     if (rentalDetail?.borrowerField) {
-      const entries = Object.entries(rentalDetail.borrowerField).filter(
-        ([, v]) => typeof v === "string" && v.trim().length > 0,
-      );
-      const filteredEntries = contactFromBorrowerField.key
-        ? entries.filter(([k]) => k !== contactFromBorrowerField.key)
-        : entries;
-
-      const values = filteredEntries.map(([, v]) => v);
-      return values.length > 0 ? values.join(" | ") : "대여자 정보";
+      if (borrowerFieldNameOnly) return borrowerFieldNameOnly;
+      return applicantPropParsed.name || applicantProp?.trim() || "대여자 정보";
     }
     return applicantPropParsed.name || (applicantProp ?? "대여자 정보");
   }, [
     rentalDetail?.borrowerField,
     applicantProp,
     applicantPropParsed.name,
-    contactFromBorrowerField.key,
+    borrowerFieldNameOnly,
   ]);
   const isDetailReady = shouldFetchRentalDetail ? !!rentalDetail : true;
   const canSubmit = useMemo(
@@ -302,14 +312,16 @@ const LongRentalApprovalModal = ({
                 <div className="flex flex-col px-1.75 pb-4.25">
                   <p className="text-14px text-neutral-gray-1 opacity-[0.9] leading-[140%]">
                     • 대여 기간:{" "}
-                    {Number.isFinite(rentalDurationDays) &&
-                    (rentalDurationDays ?? 0) > 0
-                      ? `${rentalDurationDays}일`
+                    {Number.isFinite(rentalDuration) &&
+                    (rentalDuration ?? 0) > 0
+                      ? `${rentalDuration}일`
                       : "정보 없음"}
                   </p>
                   <p className="text-14px text-neutral-gray-1 opacity-[0.9] leading-[140%]">
                     • 보증 물품:{" "}
-                    {guaranteedGoods?.trim() ? guaranteedGoods.trim() : "없음"}
+                    {guaranteedGoods?.trim()
+                      ? guaranteedGoods.trim() == null
+                      : "없음"}
                   </p>
                 </div>
               </div>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,5 @@
-export const GA_CONSENT_STORAGE_KEY = "ga4ConsentGranted";
+export const ADMIN_GA_CONSENT_STORAGE_KEY = "adminGa4ConsentGranted";
+export const CLIENT_GA_CONSENT_STORAGE_KEY = "clientGa4ConsentGranted";
 
 declare global {
   interface Window {
@@ -42,7 +43,11 @@ export const initializeGA4 = () => {
     send_page_view: false,
   });
 
-  if (localStorage.getItem(GA_CONSENT_STORAGE_KEY) === "true") {
+  const hasConsent =
+    localStorage.getItem(ADMIN_GA_CONSENT_STORAGE_KEY) === "true" ||
+    localStorage.getItem(CLIENT_GA_CONSENT_STORAGE_KEY) === "true";
+
+  if (hasConsent) {
     grantAnalyticsConsent();
   }
 };

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -29,14 +29,7 @@ const LandingPage = () => {
         <Button
           variant="primary"
           size="lg"
-          onClick={() =>
-            navigate("/terms", {
-              state: {
-                userType: "client",
-                nextPath: "/client-search",
-              },
-            })
-          }
+          onClick={() => navigate("/client-search")}
         >
           대여하기
         </Button>

--- a/src/pages/TermsConsentPage.tsx
+++ b/src/pages/TermsConsentPage.tsx
@@ -5,7 +5,8 @@ import { Layout } from "../components/Layout";
 import Button from "../components/Button";
 import CustomCheckBox from "../components/CustomCheckbox";
 import {
-  GA_CONSENT_STORAGE_KEY,
+  ADMIN_GA_CONSENT_STORAGE_KEY,
+  CLIENT_GA_CONSENT_STORAGE_KEY,
   grantAnalyticsConsent,
   trackPageView,
 } from "../lib/analytics";
@@ -22,6 +23,11 @@ type TermsRouteState = {
 const PAGE_DESTINATION_BY_USER_TYPE: Record<"admin" | "client", string> = {
   admin: "/login",
   client: "/",
+};
+
+const CONSENT_STORAGE_KEY_BY_USER_TYPE: Record<"admin" | "client", string> = {
+  admin: ADMIN_GA_CONSENT_STORAGE_KEY,
+  client: CLIENT_GA_CONSENT_STORAGE_KEY,
 };
 
 const TERMS_CONTENT_BY_USER_TYPE: Record<"admin" | "client", string> = {
@@ -224,11 +230,12 @@ const TermsConsentPage = () => {
 
   const [isTermsChecked, setIsTermsChecked] = useState(false);
   const [isPrivacyChecked, setIsPrivacyChecked] = useState(false);
+  const userType = effectiveState?.userType ?? "admin";
+  const consentStorageKey = CONSENT_STORAGE_KEY_BY_USER_TYPE[userType];
   const hasGrantedAnalyticsRef = useRef(
     typeof window !== "undefined" &&
-      localStorage.getItem(GA_CONSENT_STORAGE_KEY) === "true",
+      localStorage.getItem(consentStorageKey) === "true",
   );
-  const userType = effectiveState?.userType ?? "admin";
   const termsContent = TERMS_CONTENT_BY_USER_TYPE[userType];
   const privacyContent = PRIVACY_CONTENT_BY_USER_TYPE[userType];
 
@@ -265,7 +272,7 @@ const TermsConsentPage = () => {
       // 첫 동의 시점에만 page_view와 영구 동의 상태를 기록한다.
       if (!hasGrantedAnalyticsRef.current) {
         trackPageView(`${location.pathname}${location.search}`);
-        localStorage.setItem(GA_CONSENT_STORAGE_KEY, "true");
+        localStorage.setItem(consentStorageKey, "true");
         hasGrantedAnalyticsRef.current = true;
       }
     }

--- a/src/pages/admin/RentalRequestPage.tsx
+++ b/src/pages/admin/RentalRequestPage.tsx
@@ -15,11 +15,7 @@ const RentalRequestPage = () => {
 
   return (
     <Layout>
-      <Header
-        name={organizationName}
-        pageName="대여요청"
-        backTo="/home"
-      ></Header>
+      <Header name={organizationName} pageName="대여요청" backTo="/home" />
       <div className="flex flex-col w-full h-screen items-center my-6.5 gap-5 overflow-y-auto no-scrollbar">
         {isLoading && (
           <p className="text-neutral-gray-3 text-14px">로딩 중...</p>

--- a/src/pages/client/RentalInformationSubmitPage.tsx
+++ b/src/pages/client/RentalInformationSubmitPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import type { FormEvent } from "react";
 import { Layout } from "../../components/Layout";
@@ -117,6 +117,10 @@ const RentalInformationSubmitPage = () => {
   const [phoneVerificationTokenId, setPhoneVerificationTokenId] = useState("");
   const [isPhoneVerificationComplete, setIsPhoneVerificationComplete] =
     useState(false);
+  /** 인증번호 전송: 한 번 시도한 뒤(성공/실패 무관) 새로고침 전까지 재전송 불가 */
+  const [isPhoneVerificationSendPermanentlyDisabled, setIsPhoneVerificationSendPermanentlyDisabled] =
+    useState(false);
+  const phoneVerificationSendLockRef = useRef(false);
   const [requestment, setRequestment] = useState("");
   const [additionalFieldValues, setAdditionalFieldValues] = useState<
     Record<string, string>
@@ -164,6 +168,9 @@ const RentalInformationSubmitPage = () => {
   const handleSendPhoneVerificationCode = () => {
     if (isPhoneVerificationComplete) return;
     if (!isValidPhoneNumberForVerification) return;
+    if (phoneVerificationSendLockRef.current) return;
+    phoneVerificationSendLockRef.current = true;
+    setIsPhoneVerificationSendPermanentlyDisabled(true);
 
     const normalizedPhoneNumber = formatPhoneNumber(phoneNumber.trim());
 
@@ -393,7 +400,8 @@ const RentalInformationSubmitPage = () => {
                 disabled={
                   !isValidPhoneNumberForVerification ||
                   isSendingPhoneCode ||
-                  isPhoneVerificationComplete
+                  isPhoneVerificationComplete ||
+                  isPhoneVerificationSendPermanentlyDisabled
                 }
                 onClick={handleSendPhoneVerificationCode}
               >


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

<!-- 작업한 내용을 작성해주세요 -->

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 임대 상세에 보증물(보증금/보증물) 및 요청 메모 표시 추가
  * 관리자 승인 모달에 보증물 텍스트와 대여 기간 표시 강화

* **버그 수정**
  * 휴대폰 인증번호 재전송 차단 (페이지 새로고침 전까지 재전송 불가)

* **개선 사항**
  * 관리자/클라이언트별 약관 및 분석 동의 처리 분리
  * 랜딩 페이지 기본 CTA를 클라이언트 검색으로 직접 이동하도록 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->