### PR TITLE
[RTR-264] Design: 멤버쉽 관리 페이지 1차 구현

### DIFF
--- a/public/icons/membership/calendar.svg
+++ b/public/icons/membership/calendar.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 16.6344 15.5094" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M13.9422 1.00471H2.69221C1.76023 1.00471 1.00471 1.76023 1.00471 2.69221V12.8172C1.00471 13.7492 1.76023 14.5047 2.69221 14.5047H13.9422C14.8742 14.5047 15.6297 13.7492 15.6297 12.8172V2.69221C15.6297 1.76023 14.8742 1.00471 13.9422 1.00471Z" stroke="var(--stroke-0, #E6EAED)" stroke-width="2.00942" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/membership/plus.svg
+++ b/public/icons/membership/plus.svg
@@ -1,0 +1,18 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 46 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Union" filter="url(#filter0_d_0_158)">
+<path d="M24.5172 21.4834H29V24.5172H24.5172V29H21.4828V24.5172H17V21.4834H21.4828V17H24.5172V21.4834Z" fill="var(--fill-0, #133E7E)"/>
+</g>
+<defs>
+<filter id="filter0_d_0_158" x="0" y="0" width="46" height="46" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="1" operator="dilate" in="SourceAlpha" result="effect1_dropShadow_0_158"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="8"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.710862 0 0 0 0 0.956629 0 0 0 0 1 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_0_158"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_0_158" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ModalTestPage } from "./pages/ModalTestPage";
 import LoginPage from "./pages/admin/LoginPage";
 import HomePage from "./pages/admin/HomePage";
 import AccountPage from "./pages/admin/AccountPage";
+import MembershipPage from "./pages/admin/MembershipPage";
 import ProfileEditPage from "./pages/admin/ProfileEditPage";
 import LandingPage from "./pages/LandingPage";
 import RegisterPage from "./pages/admin/RegisterPage";
@@ -129,6 +130,7 @@ function App() {
         <Route element={<AuthGate />}>
           <Route path="/home" element={<HomePage />} />
           <Route path="/account" element={<AccountPage />} />
+          <Route path="/membership" element={<MembershipPage />} />
           <Route path="/profile" element={<ProfileEditPage />} />
           <Route path="/item-manage" element={<ItemManagementPage />} />
           <Route path="/item-register" element={<ItemRegisterationPage />} />

--- a/src/components/membership/MembershipCouponCard.tsx
+++ b/src/components/membership/MembershipCouponCard.tsx
@@ -1,0 +1,108 @@
+import MembershipStatusBadge, {
+  type MembershipCouponStatus,
+} from "./MembershipStatusBadge";
+
+export type MembershipCouponCardProps = {
+  title: string;
+  eventName: string;
+  period: string;
+  status: MembershipCouponStatus;
+  periodLabel?: "사용 기간" | "유효 기간";
+  compact?: boolean;
+  preview?: boolean;
+};
+
+const ACCENT_STYLES: Record<MembershipCouponStatus, string> = {
+  active: "bg-secondary-5",
+  pending: "bg-secondary-4",
+  completed: "bg-secondary-5",
+};
+
+const TITLE_STYLES: Record<MembershipCouponStatus, string> = {
+  active: "text-[#133e7e]",
+  pending: "text-[#133e7e]",
+  completed: "text-neutral-gray-3",
+};
+
+const EVENT_STYLES: Record<MembershipCouponStatus, string> = {
+  active: "text-neutral-gray-2",
+  pending: "text-neutral-gray-2",
+  completed: "text-neutral-gray-4",
+};
+
+const PERIOD_STYLES: Record<MembershipCouponStatus, string> = {
+  active: "text-secondary-2",
+  pending: "text-secondary-2",
+  completed: "text-neutral-gray-4",
+};
+
+const MembershipCouponCard = ({
+  title,
+  eventName,
+  period,
+  status,
+  periodLabel = status === "pending" ? "유효 기간" : "사용 기간",
+  compact = false,
+  preview = false,
+}: MembershipCouponCardProps) => {
+  const isCompleted = status === "completed";
+  const accentClass = preview ? "bg-secondary-5" : ACCENT_STYLES[status];
+
+  return (
+    <article
+      className={`relative flex w-full overflow-hidden rounded-[8px] border border-[#e6eaed] bg-neutral-white ${
+        compact || preview
+          ? "min-h-[92px] px-[31px] py-[18px]"
+          : isCompleted
+            ? "min-h-[94px] px-6 py-5"
+            : "min-h-[102px] px-[34px] py-5"
+      }`}
+    >
+      <div
+        className={`absolute left-0 top-0 bottom-0 w-[14px] rounded-bl-[8px] rounded-tl-[8px] ${accentClass}`}
+        aria-hidden
+      />
+
+      <div
+        className="pointer-events-none absolute right-0 top-1/2 flex -translate-y-1/2 flex-col gap-[5px]"
+        aria-hidden
+      >
+        {Array.from({ length: 5 }).map((_, index) => (
+          <span
+            key={index}
+            className="size-[10px] -mr-[5px] rounded-full bg-secondary-4"
+          />
+        ))}
+      </div>
+
+      <div className="relative z-10 flex w-full flex-col gap-1 pr-4">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <p
+            className={`font-bold leading-[1.4] whitespace-nowrap ${
+              compact ? "text-[18px]" : "text-20px"
+            } ${TITLE_STYLES[status]}`}
+          >
+            {title}
+          </p>
+          <MembershipStatusBadge status={status} />
+        </div>
+        <p
+          className={`font-semibold leading-[1.4] ${
+            compact ? "text-[11px]" : "text-12px"
+          } ${EVENT_STYLES[status]}`}
+        >
+          {eventName}
+        </p>
+        <p
+          className={`self-end font-semibold leading-normal whitespace-nowrap ${
+            compact ? "text-10px" : "text-10px"
+          } ${PERIOD_STYLES[status]}`}
+        >
+          {periodLabel}: {period}
+        </p>
+      </div>
+    </article>
+  );
+};
+
+export default MembershipCouponCard;

--- a/src/components/membership/MembershipProBadge.tsx
+++ b/src/components/membership/MembershipProBadge.tsx
@@ -1,0 +1,15 @@
+const MembershipProBadge = () => {
+  return (
+    <span
+      className="inline-flex h-[18px] w-[26px] items-center justify-center rounded-[4px] text-12px font-bold leading-[1.5] text-[#133e7e] shadow-[0px_0px_0.3px_0px_rgba(45,78,127,0.5),0px_0px_12.9px_-3px_rgba(92,174,255,0.5)]"
+      style={{
+        backgroundImage:
+          "linear-gradient(90deg, rgba(0, 87, 215, 0.04) 0%, rgba(0, 87, 215, 0.04) 100%), linear-gradient(47.8deg, rgba(255, 255, 255, 0) 19.15%, rgba(255, 255, 255, 0.54) 88.66%), linear-gradient(90deg, rgba(118, 173, 255, 0.12) 0%, rgba(118, 173, 255, 0.12) 100%), linear-gradient(35.54deg, rgba(214, 235, 255, 0.68) 7.73%, rgba(255, 255, 255, 0.68) 98.16%)",
+      }}
+    >
+      pro
+    </span>
+  );
+};
+
+export default MembershipProBadge;

--- a/src/components/membership/MembershipStatusBadge.tsx
+++ b/src/components/membership/MembershipStatusBadge.tsx
@@ -1,0 +1,47 @@
+export type MembershipCouponStatus = "active" | "pending" | "completed";
+
+const STATUS_LABEL: Record<MembershipCouponStatus, string> = {
+  active: "사용중",
+  pending: "사용 전",
+  completed: "사용 완료",
+};
+
+const STATUS_STYLES: Record<
+  MembershipCouponStatus,
+  { container: string; text: string }
+> = {
+  active: {
+    container: "border-primary",
+    text: "text-primary",
+  },
+  pending: {
+    container: "border-neutral-gray-3",
+    text: "text-neutral-gray-3",
+  },
+  completed: {
+    container: "border-neutral-gray-4",
+    text: "text-neutral-gray-4",
+  },
+};
+
+type MembershipStatusBadgeProps = {
+  status: MembershipCouponStatus;
+};
+
+const MembershipStatusBadge = ({ status }: MembershipStatusBadgeProps) => {
+  const styles = STATUS_STYLES[status];
+
+  return (
+    <span
+      className={`inline-flex h-[18px] items-center justify-center rounded-[9px] border-[0.5px] border-solid bg-neutral-white px-[7px] py-px ${styles.container}`}
+    >
+      <span
+        className={`text-10px font-bold leading-[1.3] whitespace-nowrap ${styles.text}`}
+      >
+        {STATUS_LABEL[status]}
+      </span>
+    </span>
+  );
+};
+
+export default MembershipStatusBadge;

--- a/src/components/modals/membership/CouponRegistrationModal.tsx
+++ b/src/components/modals/membership/CouponRegistrationModal.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import MembershipCouponCard from "../../membership/MembershipCouponCard";
+
+export type CouponPreview = {
+  title: string;
+  eventName: string;
+  validityPeriod: string;
+  benefitPeriod: string;
+};
+
+const DEFAULT_PREVIEW: CouponPreview = {
+  title: "2달 이용권",
+  eventName: "Retrivr 출시 이벤트",
+  validityPeriod: "26. 05. 01 ~ 26. 06. 30",
+  benefitPeriod: "등록일로부터 60일 간",
+};
+
+const NOTICE_ITEMS = [
+  "이미 프로 멤버십을 이용 중인 경우, 현재 이용권 종료 후 혜택이 시작됩니다.",
+  "관련 문의: 인스타그램 DM (@Retrivr_official)",
+];
+
+const lookupCouponPreview = (code: string): CouponPreview | null => {
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) return null;
+  if (normalized.length < 4) return null;
+  return DEFAULT_PREVIEW;
+};
+
+type CouponRegistrationModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onRegister: (code: string, preview: CouponPreview) => void;
+};
+
+const CouponRegistrationModal = ({
+  isOpen,
+  onClose,
+  onRegister,
+}: CouponRegistrationModalProps) => {
+  const [couponCode, setCouponCode] = useState("");
+  const preview = lookupCouponPreview(couponCode);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setCouponCode("");
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleRegister = () => {
+    if (!preview) return;
+    onRegister(couponCode.trim().toUpperCase(), preview);
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[999] flex items-center justify-center px-8 font-[Pretendard]">
+      <button
+        type="button"
+        className="absolute inset-0 bg-[rgba(217,217,217,0.48)] cursor-default"
+        aria-label="모달 닫기"
+        onClick={onClose}
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="coupon-registration-title"
+        className="relative z-[1000] flex max-h-[min(588px,90vh)] w-full max-w-[338px] flex-col overflow-hidden rounded-[24px] bg-neutral-white shadow-16-gray"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex flex-col gap-5 overflow-y-auto no-scrollbar px-6 pt-8">
+          <h2
+            id="coupon-registration-title"
+            className="text-20px font-semibold leading-[1.4] text-secondary-1"
+          >
+            쿠폰 등록하기
+          </h2>
+
+          <input
+            type="text"
+            value={couponCode}
+            onChange={(event) =>
+              setCouponCode(event.target.value.toUpperCase())
+            }
+            placeholder="쿠폰 코드를 입력해주세요"
+            className="h-12 w-full rounded-[12px] bg-neutral-gray-5 px-3.5 text-14px font-normal leading-[1.4] text-neutral-gray-2 outline-none placeholder:text-neutral-gray-3 focus:ring-2 focus:ring-primary/30"
+            autoFocus
+          />
+
+          <div className="-mx-6 flex flex-col gap-6 bg-secondary-4 px-6 py-6">
+            {preview ? (
+              <MembershipCouponCard
+                title={preview.title}
+                eventName={preview.eventName}
+                period={preview.validityPeriod}
+                status="pending"
+                periodLabel="유효 기간"
+                compact
+                preview
+              />
+            ) : (
+              <p className="py-4 text-center text-14px font-normal leading-[1.4] text-neutral-gray-3">
+                쿠폰 코드를 입력하면 미리보기가 표시됩니다
+              </p>
+            )}
+
+            <div className="flex flex-col gap-2.5">
+              <div className="flex flex-col gap-0.5">
+                <p className="text-14px font-semibold leading-5 text-secondary-1">
+                  혜택 기간
+                </p>
+                <p className="text-14px font-normal leading-[1.4] text-neutral-gray-2">
+                  {preview?.benefitPeriod ?? "등록일로부터 60일 간"}
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-0.5">
+                <p className="text-14px font-semibold leading-5 text-secondary-1">
+                  유효 기간
+                </p>
+                <p className="text-14px font-normal leading-[1.4] text-neutral-gray-2">
+                  {preview?.validityPeriod ?? "-"}
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-[3px]">
+                <p className="text-14px font-semibold leading-5 text-secondary-1">
+                  안내 사항
+                </p>
+                <ul className="flex flex-col gap-2">
+                  {NOTICE_ITEMS.map((notice) => (
+                    <li key={notice} className="flex gap-0.5">
+                      <span
+                        className="mt-[7px] size-[17px] shrink-0 flex items-center justify-center"
+                        aria-hidden
+                      >
+                        <span className="size-[2px] rounded-full bg-neutral-gray-2" />
+                      </span>
+                      <p className="text-14px font-normal leading-[1.4] text-neutral-gray-2">
+                        {notice}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="shrink-0 px-6 pb-6 pt-4">
+          <button
+            type="button"
+            onClick={handleRegister}
+            disabled={!preview}
+            className="flex h-12 w-full items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-primary transition-colors enabled:cursor-pointer enabled:hover:bg-secondary-2 disabled:cursor-not-allowed disabled:bg-neutral-gray-4"
+          >
+            등록하기
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.getElementById("modal-root")!,
+  );
+};
+
+export default CouponRegistrationModal;

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -19,7 +19,7 @@ const getPublicWebOrigin = () => {
 };
 
 const AccountPage = () => {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
   const { data } = useAdminProfile();
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";
@@ -18,6 +19,7 @@ const getPublicWebOrigin = () => {
 };
 
 const AccountPage = () => {
+  const navigate = useNavigate();
   const { data } = useAdminProfile();
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
@@ -208,6 +210,17 @@ const AccountPage = () => {
                 사진 다운로드
               </button>
             </div>
+          </div>
+          {/* Retrivr 프로 - 멤버십 페이지 */}
+          <div className="flex flex-col w-full h-13.25 text-14px font-bold shadow-16-gray rounded-2xl">
+            <button
+              type="button"
+              onClick={() => navigate("/membership")}
+              className="flex items-center justify-between h-13.25 px-7.5 rounded-2xl cursor-pointer hover:bg-neutral-gray-4/50"
+            >
+              <p className="text-start text-primary">Retrivr 프로</p>
+              <img src="/icons/right-arrow2.svg" alt="" />
+            </button>
           </div>
           {/* 이용약관, 개인정보 처리 방침 */}
           <div className="flex flex-col w-full h-26.5 text-14px font-bold shadow-16-gray rounded-2xl">

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -215,7 +215,7 @@ const AccountPage = () => {
           <div className="flex flex-col w-full h-13.25 text-14px font-bold shadow-16-gray rounded-2xl">
             <button
               type="button"
-              onClick={() => navigate("/membership")}
+              onClick={() => alert("개발 예정입니다.")}
               className="flex items-center justify-between h-13.25 px-7.5 rounded-2xl cursor-pointer hover:bg-neutral-gray-4/50"
             >
               <p className="text-start text-primary">Retrivr 프로</p>

--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -116,11 +116,15 @@ const LoginPage = () => {
           <p className="text-center text-primary text-14px font-normal leading-none">
             회원이 아니신가요?
           </p>
-          {/* 회원가입 버튼 : /register 로 이동 */}
+          {/* 회원가입 버튼 : 약관 동의 후 /register 로 이동 */}
           <Button
             variant="outline"
             size="lg"
-            onClick={() => navigate("/terms", { state: { userType: "admin" } })}
+            onClick={() =>
+              navigate("/terms", {
+                state: { userType: "admin", nextPath: "/register" },
+              })
+            }
           >
             회원가입
           </Button>

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -1,0 +1,283 @@
+import { useState } from "react";
+import { Layout } from "../../components/Layout";
+import Header from "../../components/Header";
+import ConfirmModal from "../../components/modals/ConfirmModal";
+import CouponRegistrationModal, {
+  type CouponPreview,
+} from "../../components/modals/membership/CouponRegistrationModal";
+import MembershipCouponCard from "../../components/membership/MembershipCouponCard";
+import MembershipProBadge from "../../components/membership/MembershipProBadge";
+
+type MembershipTab = "subscription" | "voucher";
+
+const ACTIVE_VOUCHER = {
+  title: "2달 이용권",
+  eventName: "Retrivr 출시 이벤트",
+  period: "26. 05. 01 ~ 26. 06. 30",
+};
+
+const AVAILABLE_VOUCHERS = [
+  {
+    id: "voucher-1",
+    title: "2달 이용권",
+    eventName: "Retrivr 출시 이벤트",
+    period: "26. 05. 01 ~ 26. 06. 30",
+    status: "active" as const,
+  },
+  {
+    id: "voucher-2",
+    title: "2달 이용권",
+    eventName: "Retrivr 출시 이벤트",
+    period: "26. 05. 01 ~ 26. 06. 30",
+    status: "pending" as const,
+  },
+];
+
+const COMPLETED_VOUCHERS = [
+  {
+    id: "completed-1",
+    title: "2달 이용권",
+    eventName: "Retrivr 출시 이벤트",
+    period: "26. 05. 01 ~ 26. 06. 30",
+  },
+  {
+    id: "completed-2",
+    title: "2달 이용권",
+    eventName: "Retrivr 출시 이벤트",
+    period: "26. 05. 01 ~ 26. 06. 30",
+  },
+  {
+    id: "completed-3",
+    title: "2달 이용권",
+    eventName: "Retrivr 출시 이벤트",
+    period: "26. 05. 01 ~ 26. 06. 30",
+  },
+];
+
+type VoucherItem = {
+  id: string;
+  title: string;
+  eventName: string;
+  period: string;
+  status: "active" | "pending";
+};
+
+const MembershipPage = () => {
+  const [activeTab, setActiveTab] = useState<MembershipTab>("voucher");
+  const [isCouponModalOpen, setIsCouponModalOpen] = useState(false);
+  const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
+    null,
+  );
+  const [availableVouchers, setAvailableVouchers] =
+    useState<VoucherItem[]>(AVAILABLE_VOUCHERS);
+
+  const handleRegisterCoupon = () => {
+    setIsCouponModalOpen(true);
+  };
+
+  const handleCouponRegister = (_code: string, preview: CouponPreview) => {
+    setAvailableVouchers((prev) => {
+      const hasPending = prev.some((voucher) => voucher.status === "pending");
+      if (hasPending) return prev;
+
+      return [
+        ...prev,
+        {
+          id: `voucher-${Date.now()}`,
+          title: preview.title,
+          eventName: preview.eventName,
+          period: preview.validityPeriod,
+          status: "pending",
+        },
+      ];
+    });
+    setIsCouponModalOpen(false);
+    setConfirmModalMessage("쿠폰이 등록되었어요");
+  };
+
+  return (
+    <Layout>
+      <Header name="계정 관리" pageName="Retrivr 프로" backTo="/account" />
+
+      <div className="flex flex-1 flex-col overflow-y-auto no-scrollbar font-[Pretendard]">
+        <section className="relative bg-gradient-to-b from-white from-[42.5%] to-secondary-4 to-[87.7%] px-8 pb-6 pt-8">
+          <div className="flex flex-col items-center gap-4">
+            <img
+              src="/icons/retrivr_text_primary.svg"
+              alt="Retrivr"
+              className="h-[38px] w-auto object-contain"
+            />
+            <h1 className="text-18px font-bold text-neutral-gray-1">
+              <span className="text-primary">리트리버 프로</span> 멤버십
+            </h1>
+          </div>
+
+          <div className="mx-auto mt-8 flex w-full max-w-[360px] flex-col items-center rounded-[26px] bg-white/40 px-[27px] py-6 shadow-[0px_0px_0px_0px_rgba(45,78,127,0.5),0px_0px_12.9px_0px_rgba(92,174,255,0.2)]">
+            <div className="flex w-full max-w-[306px] flex-col items-center gap-[29px]">
+              <div className="flex flex-col items-center gap-1">
+                <div className="flex items-center gap-2">
+                  <h2 className="text-20px font-bold leading-[1.4] text-neutral-gray-1">
+                    이용 현황
+                  </h2>
+                  <MembershipProBadge />
+                </div>
+                <p className="text-12px font-bold leading-[1.5] text-secondary-2">
+                  구독 방식: 이용권 사용
+                </p>
+              </div>
+
+              <div className="flex w-full flex-col gap-[11px]">
+                <MembershipCouponCard
+                  title={ACTIVE_VOUCHER.title}
+                  eventName={ACTIVE_VOUCHER.eventName}
+                  period={ACTIVE_VOUCHER.period}
+                  status="active"
+                  compact
+                />
+
+                <div className="flex items-center justify-between rounded-[7.5px] border border-[#e6eaed] bg-neutral-white px-[18px] py-3">
+                  <div className="flex items-center gap-1.5">
+                    <img
+                      src="/icons/membership/calendar.svg"
+                      alt=""
+                      className="size-[18px] shrink-0"
+                      aria-hidden
+                    />
+                    <span className="text-[11px] font-bold leading-[1.5] text-neutral-gray-2">
+                      다음 갱신일
+                    </span>
+                  </div>
+                  <span className="text-[11px] font-bold leading-[1.5] text-neutral-gray-2">
+                    2026. 07. 01
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="flex flex-1 flex-col rounded-t-[24px] bg-neutral-white px-8 pb-10 shadow-[0px_2px_12px_0px_rgba(116,132,155,0.25)]">
+          <div className="flex w-full">
+            <button
+              type="button"
+              onClick={() => setActiveTab("subscription")}
+              className="flex h-[57px] flex-1 flex-col items-center justify-end gap-4"
+            >
+              <span
+                className={`text-18px font-bold ${
+                  activeTab === "subscription"
+                    ? "text-secondary-1"
+                    : "text-neutral-gray-4"
+                }`}
+              >
+                요금제 구독
+              </span>
+              <span
+                className={`h-[3px] w-full ${
+                  activeTab === "subscription"
+                    ? "bg-primary"
+                    : "bg-neutral-gray-5"
+                }`}
+              />
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab("voucher")}
+              className="flex h-[57px] flex-1 flex-col items-center justify-end gap-4"
+            >
+              <span
+                className={`text-18px font-bold ${
+                  activeTab === "voucher"
+                    ? "text-secondary-1"
+                    : "text-neutral-gray-4"
+                }`}
+              >
+                이용권
+              </span>
+              <span
+                className={`h-[3px] w-full ${
+                  activeTab === "voucher" ? "bg-primary" : "bg-neutral-gray-5"
+                }`}
+              />
+            </button>
+          </div>
+
+          {activeTab === "voucher" ? (
+            <div className="mt-6 flex flex-col gap-8">
+              <button
+                type="button"
+                onClick={handleRegisterCoupon}
+                className="flex h-13 w-full items-center justify-center rounded-[12px] bg-neutral-white drop-shadow-[0px_0px_2px_rgba(148,169,201,0.5)] cursor-pointer"
+              >
+                <img
+                  src="/icons/membership/plus.svg"
+                  alt=""
+                  className="size-12"
+                  aria-hidden
+                />
+                <span className="text-14px font-bold text-secondary-1">
+                  쿠폰 등록하기
+                </span>
+              </button>
+
+              <div className="flex flex-col gap-2.5">
+                <h3 className="text-18px font-bold text-secondary-1">이용권</h3>
+                <div className="flex flex-col gap-2.5">
+                  {availableVouchers.map((voucher) => (
+                    <MembershipCouponCard
+                      key={voucher.id}
+                      title={voucher.title}
+                      eventName={voucher.eventName}
+                      period={voucher.period}
+                      status={voucher.status}
+                      periodLabel={
+                        voucher.status === "pending" ? "유효 기간" : "사용 기간"
+                      }
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2.5">
+                <p className="text-14px font-semibold leading-5 text-neutral-gray-3">
+                  사용 완료
+                </p>
+                <div className="flex flex-col gap-2.5">
+                  {COMPLETED_VOUCHERS.map((voucher) => (
+                    <MembershipCouponCard
+                      key={voucher.id}
+                      title={voucher.title}
+                      eventName={voucher.eventName}
+                      period={voucher.period}
+                      status="completed"
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-10 flex flex-col items-center justify-center py-16 text-center">
+              <p className="text-14px font-bold text-secondary-2">
+                요금제 구독은 준비 중이에요
+              </p>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <CouponRegistrationModal
+        isOpen={isCouponModalOpen}
+        onClose={() => setIsCouponModalOpen(false)}
+        onRegister={handleCouponRegister}
+      />
+      <ConfirmModal
+        isOpen={confirmModalMessage !== null}
+        onClose={() => setConfirmModalMessage(null)}
+        message={confirmModalMessage ?? ""}
+        confirmText="확인"
+      />
+    </Layout>
+  );
+};
+
+export default MembershipPage;


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

피그마 MCP를 이용하여 해당 페이지 및 쿠폰 등록 모달을 구현해봤습니다. 세세한 css 수정은 차후에 적용할 예정입니다.

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->

## 📷 Screenshot

<img width="504" height="910" alt="image" src="https://github.com/user-attachments/assets/8f7cc65c-7c4d-451c-807d-f7a8db14ac69" />

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멤버십 페이지 추가: 구독/이용권 목록, 탭별 보기 및 상태 표시
  * 쿠폰 등록 모달: 코드 입력, 미리보기 및 등록 처리
  * 이용권 카드 및 상태 배지 UI 추가: 상태별 뱃지·라벨·레이아웃 반영
  * 프로 배지 표시 추가
  * 계정 화면에서 멤버십으로 바로 이동하는 버튼 추가 및 회원가입 흐름의 경로 인자 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->