### PR TITLE
Fix GA4 collect 요청 미전송 (Consent Mode 초기화)

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -11,14 +11,29 @@ declare global {
 const GA_SCRIPT_ID = "ga4-script";
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_ID;
 
+let analyticsConsentGranted = false;
+
 const canUseGA = () =>
   typeof window !== "undefined" &&
   typeof document !== "undefined" &&
   typeof GA_MEASUREMENT_ID === "string" &&
   GA_MEASUREMENT_ID.length > 0;
 
+export const hasAnalyticsConsent = () => {
+  if (analyticsConsentGranted) return true;
+
+  if (typeof window === "undefined") return false;
+
+  return (
+    localStorage.getItem(ADMIN_GA_CONSENT_STORAGE_KEY) === "true" ||
+    localStorage.getItem(CLIENT_GA_CONSENT_STORAGE_KEY) === "true"
+  );
+};
+
 export const initializeGA4 = () => {
   if (!canUseGA()) return;
+
+  analyticsConsentGranted = hasAnalyticsConsent();
 
   if (!document.getElementById(GA_SCRIPT_ID)) {
     const script = document.createElement("script");
@@ -31,30 +46,24 @@ export const initializeGA4 = () => {
   window.dataLayer = window.dataLayer || [];
   window.gtag =
     window.gtag ||
-    function gtag(...args: unknown[]) {
-      window.dataLayer.push(args);
+    function gtag() {
+      window.dataLayer.push(arguments);
     };
 
   window.gtag("js", new Date());
   window.gtag("consent", "default", {
-    analytics_storage: "denied",
+    analytics_storage: analyticsConsentGranted ? "granted" : "denied",
+    ...(analyticsConsentGranted ? {} : { wait_for_update: 500 }),
   });
   window.gtag("config", GA_MEASUREMENT_ID, {
     send_page_view: false,
   });
-
-  const hasConsent =
-    localStorage.getItem(ADMIN_GA_CONSENT_STORAGE_KEY) === "true" ||
-    localStorage.getItem(CLIENT_GA_CONSENT_STORAGE_KEY) === "true";
-
-  if (hasConsent) {
-    grantAnalyticsConsent();
-  }
 };
 
 export const grantAnalyticsConsent = () => {
   if (!canUseGA() || typeof window.gtag !== "function") return;
 
+  analyticsConsentGranted = true;
   window.gtag("consent", "update", {
     analytics_storage: "granted",
   });
@@ -62,6 +71,7 @@ export const grantAnalyticsConsent = () => {
 
 export const trackPageView = (pagePath: string) => {
   if (!canUseGA() || typeof window.gtag !== "function") return;
+  if (!hasAnalyticsConsent()) return;
 
   window.gtag("event", "page_view", {
     page_path: pagePath,
@@ -69,4 +79,3 @@ export const trackPageView = (pagePath: string) => {
     page_title: document.title,
   });
 };
-

--- a/src/pages/TermsConsentPage.tsx
+++ b/src/pages/TermsConsentPage.tsx
@@ -271,9 +271,9 @@ const TermsConsentPage = () => {
 
       // 첫 동의 시점에만 page_view와 영구 동의 상태를 기록한다.
       if (!hasGrantedAnalyticsRef.current) {
-        trackPageView(`${location.pathname}${location.search}`);
         localStorage.setItem(consentStorageKey, "true");
         hasGrantedAnalyticsRef.current = true;
+        trackPageView(`${location.pathname}${location.search}`);
       }
     }
 


### PR DESCRIPTION
## Summary
- localStorage에 동의가 있으면 `consent default`를 `granted`로 설정해 config 이전에 반영
- 신규 방문자는 `wait_for_update`로 동의 UI 대기
- `trackPageView`는 동의 후에만 전송
- gtag stub을 Google 공식 스니펫(`dataLayer.push(arguments)`) 방식으로 수정

## Test plan
- [ ] `https://www.retrivr.kr` 접속 후 Network 탭에서 `collect` 요청 확인
- [ ] 약관 동의 후 page_view 이벤트 전송 확인
- [ ] GA4 Realtime/DebugView에서 활성 사용자 확인


Made with [Cursor](https://cursor.com)