### PR TITLE
Fix admin/client GA·약관 동의 분리 및 대여자 sessionStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,22 +27,9 @@ import ClientHomePage from "./pages/client/ClientHomePage";
 import RentalInformationSubmitPage from "./pages/client/RentalInformationSubmitPage";
 import RenterSearchPage from "./pages/client/RenterSearchPage";
 import RentalConfirmationPage from "./pages/client/RentalConfirmationPage";
-import {
-  ADMIN_GA_CONSENT_STORAGE_KEY,
-  CLIENT_GA_CONSENT_STORAGE_KEY,
-  trackPageView,
-} from "./lib/analytics";
+import { hasTermsConsent, trackPageView } from "./lib/analytics";
 
 type UserType = "admin" | "client";
-
-const hasTermsConsent = (userType: UserType) => {
-  if (typeof window === "undefined") return false;
-  const consentKey =
-    userType === "client"
-      ? CLIENT_GA_CONSENT_STORAGE_KEY
-      : ADMIN_GA_CONSENT_STORAGE_KEY;
-  return localStorage.getItem(consentKey) === "true";
-};
 
 const isAuthenticated = () =>
   typeof window !== "undefined" && Boolean(localStorage.getItem("accessToken"));

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,9 @@
+export const ADMIN_TERMS_CONSENT_STORAGE_KEY = "adminTermsConsentGranted";
+export const CLIENT_TERMS_CONSENT_STORAGE_KEY = "clientTermsConsentGranted";
 export const ADMIN_GA_CONSENT_STORAGE_KEY = "adminGa4ConsentGranted";
 export const CLIENT_GA_CONSENT_STORAGE_KEY = "clientGa4ConsentGranted";
+
+export type AnalyticsUserType = "admin" | "client";
 
 declare global {
   interface Window {
@@ -11,7 +15,26 @@ declare global {
 const GA_SCRIPT_ID = "ga4-script";
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_ID;
 
-let analyticsConsentGranted = false;
+const inMemoryAnalyticsConsent: Record<AnalyticsUserType, boolean> = {
+  admin: false,
+  client: false,
+};
+
+const ADMIN_PATH_PREFIXES = [
+  "/login",
+  "/register",
+  "/terms",
+  "/home",
+  "/account",
+  "/membership",
+  "/profile",
+  "/item-manage",
+  "/item-register",
+  "/item-edit",
+  "/return-manage",
+  "/return-check",
+  "/rental-request",
+];
 
 const canUseGA = () =>
   typeof window !== "undefined" &&
@@ -19,21 +42,72 @@ const canUseGA = () =>
   typeof GA_MEASUREMENT_ID === "string" &&
   GA_MEASUREMENT_ID.length > 0;
 
-export const hasAnalyticsConsent = () => {
-  if (analyticsConsentGranted) return true;
+const getConsentStorage = (userType: AnalyticsUserType) =>
+  userType === "client" ? sessionStorage : localStorage;
 
+const getTermsConsentStorageKey = (userType: AnalyticsUserType) =>
+  userType === "client"
+    ? CLIENT_TERMS_CONSENT_STORAGE_KEY
+    : ADMIN_TERMS_CONSENT_STORAGE_KEY;
+
+const getAnalyticsConsentStorageKey = (userType: AnalyticsUserType) =>
+  userType === "client"
+    ? CLIENT_GA_CONSENT_STORAGE_KEY
+    : ADMIN_GA_CONSENT_STORAGE_KEY;
+
+export const hasTermsConsent = (userType: AnalyticsUserType) => {
   if (typeof window === "undefined") return false;
 
   return (
-    localStorage.getItem(ADMIN_GA_CONSENT_STORAGE_KEY) === "true" ||
-    localStorage.getItem(CLIENT_GA_CONSENT_STORAGE_KEY) === "true"
+    getConsentStorage(userType).getItem(getTermsConsentStorageKey(userType)) ===
+    "true"
   );
+};
+
+export const setTermsConsent = (userType: AnalyticsUserType) => {
+  getConsentStorage(userType).setItem(
+    getTermsConsentStorageKey(userType),
+    "true",
+  );
+};
+
+export const hasAnalyticsConsent = (userType: AnalyticsUserType) => {
+  if (inMemoryAnalyticsConsent[userType]) return true;
+  if (typeof window === "undefined") return false;
+
+  return (
+    getConsentStorage(userType).getItem(
+      getAnalyticsConsentStorageKey(userType),
+    ) === "true"
+  );
+};
+
+const hasAnyAnalyticsConsent = () =>
+  hasAnalyticsConsent("admin") || hasAnalyticsConsent("client");
+
+export const resolveAnalyticsUserType = (
+  pathname: string,
+): AnalyticsUserType | null => {
+  if (pathname.startsWith("/client")) return "client";
+
+  if (
+    ADMIN_PATH_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    )
+  ) {
+    return "admin";
+  }
+
+  return null;
 };
 
 export const initializeGA4 = () => {
   if (!canUseGA()) return;
 
-  analyticsConsentGranted = hasAnalyticsConsent();
+  inMemoryAnalyticsConsent.admin = hasAnalyticsConsent("admin");
+  inMemoryAnalyticsConsent.client = hasAnalyticsConsent("client");
+
+  const consentGranted = hasAnyAnalyticsConsent();
 
   if (!document.getElementById(GA_SCRIPT_ID)) {
     const script = document.createElement("script");
@@ -52,18 +126,22 @@ export const initializeGA4 = () => {
 
   window.gtag("js", new Date());
   window.gtag("consent", "default", {
-    analytics_storage: analyticsConsentGranted ? "granted" : "denied",
-    ...(analyticsConsentGranted ? {} : { wait_for_update: 500 }),
+    analytics_storage: consentGranted ? "granted" : "denied",
+    ...(consentGranted ? {} : { wait_for_update: 500 }),
   });
   window.gtag("config", GA_MEASUREMENT_ID, {
     send_page_view: false,
   });
 };
 
-export const grantAnalyticsConsent = () => {
+export const grantAnalyticsConsent = (userType: AnalyticsUserType) => {
   if (!canUseGA() || typeof window.gtag !== "function") return;
 
-  analyticsConsentGranted = true;
+  inMemoryAnalyticsConsent[userType] = true;
+  getConsentStorage(userType).setItem(
+    getAnalyticsConsentStorageKey(userType),
+    "true",
+  );
   window.gtag("consent", "update", {
     analytics_storage: "granted",
   });
@@ -71,7 +149,10 @@ export const grantAnalyticsConsent = () => {
 
 export const trackPageView = (pagePath: string) => {
   if (!canUseGA() || typeof window.gtag !== "function") return;
-  if (!hasAnalyticsConsent()) return;
+
+  const pathname = pagePath.split("?")[0] ?? pagePath;
+  const userType = resolveAnalyticsUserType(pathname);
+  if (!userType || !hasAnalyticsConsent(userType)) return;
 
   window.gtag("event", "page_view", {
     page_path: pagePath,

--- a/src/pages/TermsConsentPage.tsx
+++ b/src/pages/TermsConsentPage.tsx
@@ -1,14 +1,14 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Header from "../components/Header";
 import { Layout } from "../components/Layout";
 import Button from "../components/Button";
 import CustomCheckBox from "../components/CustomCheckbox";
 import {
-  ADMIN_GA_CONSENT_STORAGE_KEY,
-  CLIENT_GA_CONSENT_STORAGE_KEY,
   grantAnalyticsConsent,
+  setTermsConsent,
   trackPageView,
+  type AnalyticsUserType,
 } from "../lib/analytics";
 
 const CLIENT_TERMS_REDIRECT_STORAGE_KEY = "clientTermsRedirectPayload";
@@ -23,11 +23,6 @@ type TermsRouteState = {
 const PAGE_DESTINATION_BY_USER_TYPE: Record<"admin" | "client", string> = {
   admin: "/login",
   client: "/",
-};
-
-const CONSENT_STORAGE_KEY_BY_USER_TYPE: Record<"admin" | "client", string> = {
-  admin: ADMIN_GA_CONSENT_STORAGE_KEY,
-  client: CLIENT_GA_CONSENT_STORAGE_KEY,
 };
 
 const TERMS_CONTENT_BY_USER_TYPE: Record<"admin" | "client", string> = {
@@ -230,12 +225,7 @@ const TermsConsentPage = () => {
 
   const [isTermsChecked, setIsTermsChecked] = useState(false);
   const [isPrivacyChecked, setIsPrivacyChecked] = useState(false);
-  const userType = effectiveState?.userType ?? "admin";
-  const consentStorageKey = CONSENT_STORAGE_KEY_BY_USER_TYPE[userType];
-  const hasGrantedAnalyticsRef = useRef(
-    typeof window !== "undefined" &&
-      localStorage.getItem(consentStorageKey) === "true",
-  );
+  const userType: AnalyticsUserType = effectiveState?.userType ?? "admin";
   const termsContent = TERMS_CONTENT_BY_USER_TYPE[userType];
   const privacyContent = PRIVACY_CONTENT_BY_USER_TYPE[userType];
 
@@ -266,16 +256,11 @@ const TermsConsentPage = () => {
 
   // 약관 동의 완료 후 진입 목적(관리자/대여자)에 맞는 다음 화면으로 이동
   const handleNextStep = () => {
-    if (isAllRequiredChecked) {
-      grantAnalyticsConsent();
+    if (!isAllRequiredChecked) return;
 
-      // 첫 동의 시점에만 page_view와 영구 동의 상태를 기록한다.
-      if (!hasGrantedAnalyticsRef.current) {
-        localStorage.setItem(consentStorageKey, "true");
-        hasGrantedAnalyticsRef.current = true;
-        trackPageView(`${location.pathname}${location.search}`);
-      }
-    }
+    setTermsConsent(userType);
+    grantAnalyticsConsent(userType);
+    trackPageView(`${location.pathname}${location.search}`);
 
     if (userType === "client") {
       if (effectiveState?.nextState) {


### PR DESCRIPTION
## Summary
- admin/client 약관·GA consent 키 및 저장소 분리 (client: sessionStorage, admin: localStorage)
- 경로별 GA page_view 추적 (admin consent ≠ client 페이지 추적)
- 약관 필수 동의 시 GA 동의도 함께 처리 (기존 UX 유지)

## Test plan
- [ ] 대여자: 약관 동의 후 sessionStorage에 `clientTermsConsentGranted`, `clientGa4ConsentGranted` 저장 확인
- [ ] 대여자: 탭 닫은 뒤 재진입 시 약관 재동의 필요 확인
- [ ] 관리자: localStorage에 admin consent 저장 및 `/home` collect 요청 확인
- [ ] admin consent만 있는 상태에서 `/client-*` GA 미전송 확인


Made with [Cursor](https://cursor.com)