### PR TITLE
[RTR-290] 로그아웃 모달 + 회원 탈퇴 모달 제작

### DIFF
--- a/src/components/modals/admin/account/LogoutConfirmModal.tsx
+++ b/src/components/modals/admin/account/LogoutConfirmModal.tsx
@@ -1,0 +1,62 @@
+import { Modal } from "../../../Modal";
+import Button from "../../../Button";
+
+interface LogoutConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+const LogoutConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading = false,
+}: LogoutConfirmModalProps) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      showTitle={false}
+      showCloseButton={false}
+      modalClassName="!w-[338px] !rounded-[24px] !px-4 !pt-10 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+    >
+      <div className="flex w-full flex-col items-center font-[Pretendard]">
+        <div className="flex min-h-[98px] flex-col items-center justify-center gap-3 px-2">
+          <p className="text-center text-20px font-semibold leading-[140%] text-secondary-1">
+            로그아웃 하시겠어요?
+          </p>
+          <p className="text-center text-14px font-normal leading-[140%] text-primary">
+            서비스를 이용하려면
+            <br />
+            다시 로그인이 필요해요
+          </p>
+        </div>
+
+        <div className="mt-6 flex h-12 w-full gap-2">
+          <Button
+            variant="outline"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px shadow-[0_0_4px_rgba(181,244,255,0.5)]"
+            onClick={onConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? "로그아웃 중..." : "로그아웃"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default LogoutConfirmModal;

--- a/src/components/modals/admin/account/WithdrawConfirmModal.tsx
+++ b/src/components/modals/admin/account/WithdrawConfirmModal.tsx
@@ -1,0 +1,56 @@
+import { Modal } from "../../../Modal";
+import Button from "../../../Button";
+
+interface WithdrawConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const WithdrawConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+}: WithdrawConfirmModalProps) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      showTitle={false}
+      showCloseButton={false}
+      modalClassName="!w-[338px] !rounded-[24px] !px-4 !pt-10 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+    >
+      <div className="flex w-full flex-col items-center font-[Pretendard]">
+        <div className="flex min-h-[98px] flex-col items-center justify-center gap-3 px-2">
+          <p className="text-center text-20px font-semibold leading-[140%] text-secondary-1">
+            탈퇴 하시겠어요?
+          </p>
+          <p className="max-w-[167px] text-center text-14px font-normal leading-[140%] text-primary">
+            탈퇴하시면 회원정보가 모두 삭제되고 복구하실 수 없어요!
+          </p>
+        </div>
+
+        <div className="mt-6 flex h-12 w-full gap-2">
+          <Button
+            variant="outline"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px shadow-[0_0_4px_rgba(181,244,255,0.5)]"
+            onClick={onConfirm}
+          >
+            탈퇴하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default WithdrawConfirmModal;

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";
+import LogoutConfirmModal from "../../components/modals/admin/account/LogoutConfirmModal";
+import WithdrawConfirmModal from "../../components/modals/admin/account/WithdrawConfirmModal";
 import QRCodeDisplay from "../../components/qr/QRCodeDisplay";
 import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
 
@@ -18,6 +20,12 @@ const getPublicWebOrigin = () => {
   return PREVIEW_WEB_ORIGIN;
 };
 
+const clearAdminSession = () => {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("orgId");
+};
+
 const AccountPage = () => {
   const navigate = useNavigate();
   const { data } = useAdminProfile();
@@ -25,6 +33,8 @@ const AccountPage = () => {
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
     null,
   );
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
   const organizationId =
     typeof window === "undefined"
       ? null
@@ -246,7 +256,7 @@ const AccountPage = () => {
           <div className="flex flex-col w-full h-26.5 text-14px font-bold shadow-16-gray rounded-2xl">
             <button
               type="button"
-              onClick={() => alert("개발 예정입니다.")}
+              onClick={() => setIsLogoutModalOpen(true)}
               className="h-13.25 px-7.5 rounded-t-2xl cursor-pointer hover:bg-neutral-gray-4/50"
             >
               <p className="text-start">로그아웃</p>
@@ -254,7 +264,7 @@ const AccountPage = () => {
             <p className="mx-2.5 border border-neutral-gray-4 opacity-[0.3]"></p>
             <button
               type="button"
-              onClick={() => alert("개발 예정입니다.")}
+              onClick={() => setIsWithdrawModalOpen(true)}
               className="h-13.25 px-7.5 rounded-b-2xl cursor-pointer hover:bg-neutral-gray-4/50"
             >
               <p className="text-start">탈퇴하기</p>
@@ -267,6 +277,26 @@ const AccountPage = () => {
         onClose={() => setConfirmModalMessage(null)}
         message={confirmModalMessage ?? ""}
         confirmText="확인"
+      />
+      <LogoutConfirmModal
+        isOpen={isLogoutModalOpen}
+        onClose={() => setIsLogoutModalOpen(false)}
+        onConfirm={() => {
+          // TODO: 로그아웃 API 연동(RTR-282) 후 서버 세션 무효화 추가
+          clearAdminSession();
+          setIsLogoutModalOpen(false);
+          navigate("/login", { replace: true });
+        }}
+      />
+      <WithdrawConfirmModal
+        isOpen={isWithdrawModalOpen}
+        onClose={() => setIsWithdrawModalOpen(false)}
+        onConfirm={() => {
+          // TODO: 회원 탈퇴 API 연동(RTR-283) 후 서버 탈퇴 처리로 교체
+          clearAdminSession();
+          setIsWithdrawModalOpen(false);
+          navigate("/login", { replace: true });
+        }}
       />
     </Layout>
   );


### PR DESCRIPTION
## 작업 내용
- `LogoutConfirmModal`, `WithdrawConfirmModal` 컴포넌트 신규 생성
- 계정 관리 페이지의 로그아웃/탈퇴하기 버튼에 모달 연결 (기존 `alert("개발 예정입니다.")` 대체)
- 확인 시 클라이언트 세션(accessToken/refreshToken/orgId) 정리 후 `/login`으로 이동

## 참고
- 서버 API 호출은 이 PR에 포함되지 않습니다. 로그아웃 API 연동은 RTR-282, 회원 탈퇴 API는 RTR-283에서 진행합니다.
- 스택 순서: **RTR-290(이 PR)** → RTR-282 → RTR-283. 이 PR이 먼저 merge되어야 합니다.

Made with [Cursor](https://cursor.com)