### PR TITLE
[RTR-282] 로그아웃 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -14,6 +14,7 @@ import type {
   LoginResponse,
   AdminProfileResponse,
   LoadHomeResponse,
+  LogoutResponse,
 } from "./auth.type";
 
 //
@@ -99,7 +100,17 @@ export const requestLogin = async (
 };
 
 //
-// 5. 홈 화면 출력 API (GET)
+// 5. 로그아웃 요청 API (POST)
+// 엔드포인트: "/api/admin/v1/auth/logout"
+export const requestLogout = async (): Promise<LogoutResponse> => {
+  const response = await apiClient.post<LogoutResponse>(
+    "/api/admin/v1/auth/logout",
+  );
+  return response.data;
+};
+
+//
+// 6. 홈 화면 출력 API (GET)
 // 엔드포인트 : "/api/admin/v1/home"
 export const requestLoadHome = async (): Promise<LoadHomeResponse> => {
   const response = await apiClient.get<LoadHomeResponse>("/api/admin/v1/home");
@@ -107,7 +118,7 @@ export const requestLoadHome = async (): Promise<LoadHomeResponse> => {
 };
 
 //
-// 6. 관리자 프로필 조회 API (GET)
+// 7. 관리자 프로필 조회 API (GET)
 // 엔드포인트 : "/api/admin/v1/profile"
 export const requestAdminProfile = async (): Promise<AdminProfileResponse> => {
   const response = await apiClient.get<AdminProfileResponse>(

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -98,7 +98,15 @@ export interface LoginResponse {
   refreshToken: string; // 리프레시 토큰
 }
 
-// 5. 관리자 프로필 조회
+// 5. 로그아웃 요청
+// 로그아웃 요청 바디 없음
+
+// 5-1. 로그아웃 응답 바디
+export interface LogoutResponse {
+  success: boolean;
+}
+
+// 6. 관리자 프로필 조회
 export interface AdminProfileResponse {
   organizationId: number; // 관리자 고유 번호
   organizationName: string; // 관리자 이름 (단체명)
@@ -106,10 +114,10 @@ export interface AdminProfileResponse {
   email: string; // 관리자 이메일
 }
 
-// 5. 홈 화면 출력 요청
+// 7. 홈 화면 출력 요청
 // 홈 화면 출력 요청 바디 없음
 
-// 5-1. 홈 화면 출력 응답 바디
+// 7-1. 홈 화면 출력 응답 바디
 export interface LoadHomeResponse {
   organizationId: number; // 관리자 아이디
   organizationName: string; // 관리자 이름 (단체명)

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -6,6 +6,7 @@ import {
   verifyPhoneVerificationCode,
   requestRegisteration,
   requestLogin,
+  requestLogout,
   requestLoadHome,
   requestAdminProfile,
 } from "../../api/auth/auth.api";
@@ -112,7 +113,22 @@ export const useLogin = () => {
 };
 
 //
-// 5. 홈 화면 출력 요청
+// 5. 로그아웃 요청
+//
+export const useLogout = () => {
+  return useMutation({
+    mutationFn: requestLogout,
+    onSuccess: () => {
+      console.log("로그아웃 요청 성공");
+    },
+    onError: (error: any) => {
+      console.log("로그아웃 요청 실패", error);
+    },
+  });
+};
+
+//
+// 6. 홈 화면 출력 요청
 //
 export const useLoadHome = () => {
   return useQuery({
@@ -123,7 +139,7 @@ export const useLoadHome = () => {
 };
 
 //
-// 6. 관리자 프로필 조회 요청
+// 7. 관리자 프로필 조회 요청
 //
 export const useAdminProfile = () => {
   return useQuery({

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -6,7 +6,7 @@ import ConfirmModal from "../../components/modals/ConfirmModal";
 import LogoutConfirmModal from "../../components/modals/admin/account/LogoutConfirmModal";
 import WithdrawConfirmModal from "../../components/modals/admin/account/WithdrawConfirmModal";
 import QRCodeDisplay from "../../components/qr/QRCodeDisplay";
-import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
+import { useAdminProfile, useLogout } from "../../hooks/queries/useAuthQueries";
 
 const PRODUCTION_WEB_ORIGIN = "https://www.retrivr.kr";
 const PREVIEW_WEB_ORIGIN = "https://retrivr-web.vercel.app";
@@ -29,6 +29,7 @@ const clearAdminSession = () => {
 const AccountPage = () => {
   const navigate = useNavigate();
   const { data } = useAdminProfile();
+  const { mutateAsync: logout, isPending: isLoggingOut } = useLogout();
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
     null,
@@ -281,11 +282,19 @@ const AccountPage = () => {
       <LogoutConfirmModal
         isOpen={isLogoutModalOpen}
         onClose={() => setIsLogoutModalOpen(false)}
-        onConfirm={() => {
-          // TODO: 로그아웃 API 연동(RTR-282) 후 서버 세션 무효화 추가
-          clearAdminSession();
-          setIsLogoutModalOpen(false);
-          navigate("/login", { replace: true });
+        isLoading={isLoggingOut}
+        onConfirm={async () => {
+          try {
+            // 토큰이 살아있을 때 서버 세션을 먼저 무효화
+            await logout();
+          } catch (error) {
+            // 서버 로그아웃이 실패해도 클라이언트 세션은 정리한다
+            console.error("로그아웃 요청 실패", error);
+          } finally {
+            clearAdminSession();
+            setIsLogoutModalOpen(false);
+            navigate("/login", { replace: true });
+          }
         }}
       />
       <WithdrawConfirmModal

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,12 +20,12 @@ export default defineConfig(({ mode }) => {
           target: proxyTarget,
           changeOrigin: true,
           configure: (proxy) => {
-            // 403 방지: 브라우저가 보낸 Origin(localhost:5173)이 백엔드에서 거부될 수 있어
-            // 프록시 단에서 타깃 origin으로 맞춰서 전달합니다.
+            // 백엔드 Origin 허용 목록에 localhost:5173이 없어서
+            // (로그아웃 등 Origin 검증이 있는 엔드포인트에서 403 "Origin is not allowed" 발생)
+            // 허용 목록에 포함된 localhost:3000으로 맞춰서 전달합니다.
+            // TODO: 백엔드가 localhost:5173을 허용하면 이 우회를 제거
             proxy.on("proxyReq", (proxyReq) => {
-              const baseUrl = proxyTarget;
-              const targetUrl = new URL(baseUrl);
-              proxyReq.setHeader("Origin", targetUrl.origin);
+              proxyReq.setHeader("Origin", "http://localhost:3000");
             });
           },
         },


### PR DESCRIPTION
## 작업 내용
- `requestLogout` API 함수 및 `LogoutResponse` 타입 추가 (`POST /api/admin/v1/auth/logout`)
- `useLogout` 뮤테이션 훅 추가
- 계정 관리 페이지 로그아웃 확인 시 서버 로그아웃 호출 → 성공/실패와 무관하게 클라이언트 세션 정리 후 `/login` 이동
- dev 프록시의 Origin 헤더를 백엔드 허용 목록에 있는 `http://localhost:3000`으로 변경
  - 로그아웃 엔드포인트에 Origin 검증이 있어 기존 설정(타깃 origin 전달)으로는 403 `Origin is not allowed`(code 2005)가 발생했습니다.
  - 백엔드가 `localhost:5173`을 허용하면 이 우회는 제거 예정 (TODO 주석 참고)

## 참고
- 스택 순서: RTR-290 → **RTR-282(이 PR)** → RTR-283. base가 `feature/RTR-290-account-modals`이며, RTR-290 merge 후 base를 develop으로 변경해 merge합니다.
- 백엔드 확인 필요: 로그아웃 200 이후에도 같은 accessToken으로 API 호출이 계속 성공합니다 (토큰 서버측 무효화 없음).

Made with [Cursor](https://cursor.com)