### PR TITLE
[RTR-283] 회원 탈퇴 API 코드 작성

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -15,6 +15,8 @@ import type {
   AdminProfileResponse,
   LoadHomeResponse,
   LogoutResponse,
+  WithdrawRequest,
+  WithdrawResponse,
 } from "./auth.type";
 
 //
@@ -105,6 +107,19 @@ export const requestLogin = async (
 export const requestLogout = async (): Promise<LogoutResponse> => {
   const response = await apiClient.post<LogoutResponse>(
     "/api/admin/v1/auth/logout",
+  );
+  return response.data;
+};
+
+//
+// 5-1. 회원 탈퇴 요청 API (POST)
+// 엔드포인트: "/api/admin/v1/account/withdraw"
+export const requestWithdraw = async (
+  data: WithdrawRequest,
+): Promise<WithdrawResponse> => {
+  const response = await apiClient.post<WithdrawResponse>(
+    "/api/admin/v1/account/withdraw",
+    data,
   );
   return response.data;
 };

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -106,6 +106,41 @@ export interface LogoutResponse {
   success: boolean;
 }
 
+// 5-2. 회원 탈퇴 요청
+// 엔드포인트: "/api/admin/v1/account/withdraw"
+
+// 탈퇴 사유 코드 (서버 enum)
+// 확인된 값 외에도 추가될 수 있어 string 유니언으로 열어둔다
+export type WithdrawReasonCode = "ORG_CLOSED" | (string & {});
+
+// 5-2-1. 회원 탈퇴 요청 바디
+export interface WithdrawRequest {
+  password: string; // 본인 확인용 비밀번호
+  reasonCodes: WithdrawReasonCode[]; // 탈퇴 사유 코드 목록
+  otherReason?: string; // 기타 사유 (직접 입력)
+  agreedToWarning: boolean; // 탈퇴 경고 동의 여부
+}
+
+// 5-2-2. 회원 탈퇴 응답 바디
+export interface WithdrawResponse {
+  success: boolean;
+}
+
+// 5-2-3. 회원 탈퇴 에러 응답 바디 (400/403/404 공통 스펙)
+export interface WithdrawErrorResponse {
+  status: string; // 예: "400 BAD_REQUEST"
+  code: number; // 서버 에러 코드
+  message: string; // 사용자에게 보여줄 수 있는 메시지
+  detail?: string;
+}
+
+// 회원 탈퇴 에러 코드 상수
+export const WITHDRAW_ERROR_CODE = {
+  PASSWORD_MISMATCH: 6007, // 400: 비밀번호가 일치하지 않습니다.
+  ALREADY_WITHDRAWN: 6004, // 403: 탈퇴한 계정입니다.
+  ACCOUNT_NOT_FOUND: 6002, // 404: 계정을 찾을 수 없습니다.
+} as const;
+
 // 6. 관리자 프로필 조회
 export interface AdminProfileResponse {
   organizationId: number; // 관리자 고유 번호

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -7,6 +7,7 @@ import {
   requestRegisteration,
   requestLogin,
   requestLogout,
+  requestWithdraw,
   requestLoadHome,
   requestAdminProfile,
 } from "../../api/auth/auth.api";
@@ -123,6 +124,21 @@ export const useLogout = () => {
     },
     onError: (error: any) => {
       console.log("로그아웃 요청 실패", error);
+    },
+  });
+};
+
+//
+// 5-1. 회원 탈퇴 요청
+//
+export const useWithdraw = () => {
+  return useMutation({
+    mutationFn: requestWithdraw,
+    onSuccess: () => {
+      console.log("회원 탈퇴 요청 성공");
+    },
+    onError: (error: any) => {
+      console.log("회원 탈퇴 요청 실패", error);
     },
   });
 };


### PR DESCRIPTION
## 작업 내용
- `requestWithdraw` API 함수 추가 (`POST /api/admin/v1/account/withdraw`)
- `WithdrawRequest` / `WithdrawResponse` / `WithdrawErrorResponse` 타입 및 `WITHDRAW_ERROR_CODE` 상수 추가
- `useWithdraw` 뮤테이션 훅 추가

## 참고
- API 코드만 포함하며, 탈퇴 모달에서의 호출(UI 연동)은 후속 작업에서 진행합니다. 현재 탈퇴 모달 확인 시에는 클라이언트 세션만 정리됩니다.
- 스택 순서: RTR-290 → RTR-282 → **RTR-283(이 PR)**. base가 `feature/RTR-282-logout-api`이며, 선행 PR merge 후 base를 develop으로 변경해 merge합니다.

Made with [Cursor](https://cursor.com)