### PR TITLE
fix: 로그인 버튼 중복 요청 제거 및 refreshToken optional 처리

### DIFF
--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -95,7 +95,7 @@ export interface LoginResponse {
   orgId?: number; // 레거시 필드 (하위 호환)
   email: string; // 사용자 이메일
   accessToken: string; // 엑세스 토큰
-  refreshToken: string; // 리프레시 토큰
+  refreshToken?: string; // 리프레시 토큰 (현재 서버는 HttpOnly 쿠키로 내려주어 바디에 없음)
 }
 
 // 5. 관리자 프로필 조회

--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -36,7 +36,10 @@ const LoginPage = () => {
       {
         onSuccess: (data) => {
           localStorage.setItem("accessToken", data.accessToken);
-          localStorage.setItem("refreshToken", data.refreshToken);
+          // 서버가 refreshToken을 HttpOnly 쿠키로 내려주는 경우 바디에 없을 수 있음
+          if (data.refreshToken) {
+            localStorage.setItem("refreshToken", data.refreshToken);
+          }
           const organizationId = data.organizationId ?? data.orgId;
           if (organizationId != null) {
             localStorage.setItem("orgId", String(organizationId));
@@ -96,12 +99,8 @@ const LoginPage = () => {
             disabled={isInLogin}
           />
           {/* TODO : 로그인 페이지 라우팅 및 이벤트 핸들러 설정 */}
-          <Button
-            variant="primary"
-            size="lg"
-            type="submit"
-            onClick={handleRequestLogin}
-          >
+          {/* form의 onSubmit이 로그인을 처리하므로 onClick을 중복 등록하지 않는다 (중복 요청 방지) */}
+          <Button variant="primary" size="lg" type="submit">
             {isInLogin ? "로그인 중 ..." : "로그인"}
           </Button>
           {/* TODO : 찾기 페이지 라우팅 설정 */}


### PR DESCRIPTION
## 문제
로그인 버튼 클릭 시 200과 403이 동시에 발생하고, 로그인에 성공했는데도 "로그인 정보가 없습니다" 모달이 뜨는 문제가 있었습니다.

## 원인
- 로그인 버튼이 `type="submit"`이면서 `onClick={handleRequestLogin}`도 등록되어 있어 클릭 한 번에 로그인 요청이 2번 전송됨
- 백엔드가 동일 계정의 연속 로그인 요청을 403으로 거부 (첫 요청 200, 두 번째 403)
- React Query `mutate()`를 연속 호출하면 call-site 콜백은 마지막 호출에만 실행되므로, 403을 받은 두 번째 요청의 `onError`만 실행되어 토큰 저장이 누락되고 에러 모달이 표시됨

## 수정
- 버튼의 중복 `onClick` 제거 (form `onSubmit`만으로 처리)
- 서버가 refreshToken을 HttpOnly 쿠키로 내려주어 응답 바디에 없으므로 `LoginResponse.refreshToken`을 optional로 변경하고 저장 시 가드 추가 (기존에는 문자열 "undefined"가 localStorage에 저장됨)

Made with [Cursor](https://cursor.com)