### PR TITLE
fix: 로그아웃 요청 중 배경 클릭으로 모달 닫힘 방지

### DIFF
--- a/src/components/modals/admin/account/LogoutConfirmModal.tsx
+++ b/src/components/modals/admin/account/LogoutConfirmModal.tsx
@@ -17,7 +17,9 @@ const LogoutConfirmModal = ({
   return (
     <Modal
       isOpen={isOpen}
-      onClose={onClose}
+      // 로그아웃 요청 중에는 배경 클릭으로 모달이 닫히지 않도록 막는다
+      // (닫혀도 진행 중인 로그아웃은 계속되어 세션이 정리되기 때문)
+      onClose={isLoading ? () => {} : onClose}
       showTitle={false}
       showCloseButton={false}
       modalClassName="!w-[338px] !rounded-[24px] !px-4 !pt-10 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"


### PR DESCRIPTION
## 문제
릴리즈 PR #144 리뷰에서 발견된 medium 이슈입니다. 로그아웃 요청 진행 중 취소 버튼은 비활성화되지만 모달 배경 클릭으로는 여전히 닫을 수 있었고, 닫혀도 진행 중인 로그아웃 처리는 계속되어 세션이 삭제되고 로그인 화면으로 이동했습니다.

## 수정
- `LogoutConfirmModal`에서 `isLoading`일 때 배경 클릭 닫기(`onClose`)를 차단해 취소 버튼과 동작을 일치시켰습니다.

Made with [Cursor](https://cursor.com)