### PR TITLE
fix: 로그아웃/탈퇴 시 프로필 쿼리 refetch로 인한 401 방지

### DIFF
--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -157,10 +157,11 @@ export const useLoadHome = () => {
 //
 // 7. 관리자 프로필 조회 요청
 //
-export const useAdminProfile = () => {
+export const useAdminProfile = (options?: { enabled?: boolean }) => {
   return useQuery({
     queryKey: ["adminProfile"],
     queryFn: requestAdminProfile,
     retry: false,
+    enabled: options?.enabled ?? true,
   });
 };

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { Layout } from "../../components/Layout";
@@ -30,7 +31,9 @@ const clearAdminSession = () => {
 const AccountPage = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { data } = useAdminProfile();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  // 로그아웃/탈퇴 중에는 프로필 쿼리를 꺼서 clear() 시 refetch → 401을 막는다
+  const { data } = useAdminProfile({ enabled: !isSigningOut });
   const { mutateAsync: logout, isPending: isLoggingOut } = useLogout();
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
@@ -286,6 +289,10 @@ const AccountPage = () => {
         onClose={() => setIsLogoutModalOpen(false)}
         isLoading={isLoggingOut}
         onConfirm={async () => {
+          // enabled=false가 clear() 전에 반영되도록 동기적으로 반영
+          flushSync(() => {
+            setIsSigningOut(true);
+          });
           try {
             // 토큰이 살아있을 때 서버 세션을 먼저 무효화
             await logout();
@@ -294,23 +301,31 @@ const AccountPage = () => {
             console.error("로그아웃 요청 실패", error);
           } finally {
             clearAdminSession();
-            // 다른 계정으로 재로그인 시 이전 사용자 데이터(home, adminProfile 등)가
-            // 캐시에서 노출되지 않도록 쿼리 캐시를 비운다
-            queryClient.clear();
+            await queryClient.cancelQueries();
             setIsLogoutModalOpen(false);
             navigate("/login", { replace: true });
+            // AccountPage 언마운트 이후에 캐시를 비워 활성 observer refetch를 피한다
+            queueMicrotask(() => {
+              queryClient.clear();
+            });
           }
         }}
       />
       <WithdrawConfirmModal
         isOpen={isWithdrawModalOpen}
         onClose={() => setIsWithdrawModalOpen(false)}
-        onConfirm={() => {
+        onConfirm={async () => {
           // TODO: 회원 탈퇴 API 연동(RTR-283) 후 서버 탈퇴 처리로 교체
+          flushSync(() => {
+            setIsSigningOut(true);
+          });
           clearAdminSession();
-          queryClient.clear();
+          await queryClient.cancelQueries();
           setIsWithdrawModalOpen(false);
           navigate("/login", { replace: true });
+          queueMicrotask(() => {
+            queryClient.clear();
+          });
         }}
       />
     </Layout>


### PR DESCRIPTION
## 문제
로그아웃 시 `queryClient.clear()`가 AccountPage 마운트 중에 실행되면서, 활성 `useAdminProfile` observer가 토큰 없이 `GET /profile`을 refetch해 401이 발생했습니다.

## 수정
- 로그아웃/탈퇴 시작 시 `isSigningOut`으로 프로필 쿼리 `enabled: false`
- `cancelQueries` → `/login` 이동 → `queueMicrotask`로 `queryClient.clear()`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃 또는 회원 탈퇴 중 관리자 프로필 조회가 재실행되어 인증 오류가 발생하던 문제를 수정했습니다.
  * 세션 정리 과정에서 불필요한 요청을 방지하고 로그인 화면으로 안정적으로 이동하도록 개선했습니다.
  * 관리자 프로필 조회를 필요에 따라 활성화하거나 비활성화할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->