### PR TITLE
chore: docs/local을 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local-only notes (not for GitHub)
+docs/local/


### PR DESCRIPTION
## Summary
- `docs/local/`을 `.gitignore`에 추가해 로컬 전용 노트가 GitHub에 올라가지 않도록 함

## Test plan
- [ ] `docs/local/` 파일이 `git status`에 나타나지 않는지 확인
- [ ] 다른 경로의 문서/코드 변경은 영향 없는지 확인


Made with [Cursor](https://cursor.com)