### PR TITLE
[RTR-302] 관리자 이메일 인증코드 발송 API 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,10 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <title>RETRIVR</title>
   </head>
   <body>

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -13,6 +13,8 @@ import type {
   LoginRequest,
   LoginResponse,
   AdminProfileResponse,
+  SendAdminEmailCodeRequest,
+  SendAdminEmailCodeResponse,
   LoadHomeResponse,
   LogoutResponse,
   WithdrawRequest,
@@ -138,6 +140,19 @@ export const requestLoadHome = async (): Promise<LoadHomeResponse> => {
 export const requestAdminProfile = async (): Promise<AdminProfileResponse> => {
   const response = await apiClient.get<AdminProfileResponse>(
     "/api/admin/v1/profile",
+  );
+  return response.data;
+};
+
+//
+// 7-1. 관리자 이메일 인증 코드 발송 API (POST)
+// 엔드포인트 : "/api/admin/v1/email/verification"
+export const sendAdminEmailCode = async (
+  data: SendAdminEmailCodeRequest,
+): Promise<SendAdminEmailCodeResponse> => {
+  const response = await apiClient.post<SendAdminEmailCodeResponse>(
+    "/api/admin/v1/email/verification",
+    data,
   );
   return response.data;
 };

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -1,4 +1,8 @@
-export type EmailVerificationPurpose = "SIGNUP" | "PASSWORD_RESET" | "LOGIN";
+export type EmailVerificationPurpose =
+  | "SIGNUP"
+  | "PASSWORD_RESET"
+  | "LOGIN"
+  | "EMAIL_CHANGE";
 
 // 휴대폰 인증 코드 발송/검증 목적
 // (현재 클라이언트 대여 요청에만 사용)
@@ -148,6 +152,27 @@ export interface AdminProfileResponse {
   profileImageUrl?: string; // 프로필 사진 URL
   email: string; // 관리자 이메일
 }
+
+// 6-1. 관리자 이메일 인증 코드 발송
+// 엔드포인트: "/api/admin/v1/email/verification" (POST)
+// 요청/응답 바디는 public 이메일 인증과 동일 형태 (purpose: EMAIL_CHANGE)
+
+export type SendAdminEmailCodeRequest = SendEmailCodeRequest;
+export type SendAdminEmailCodeResponse = SendEmailCodeResponse;
+
+// 관리자 이메일 인증 공통 에러 응답 (400/429 등)
+export interface AdminEmailVerificationErrorResponse {
+  status: string; // 예: "400 BAD_REQUEST", "429 TOO_MANY_REQUESTS"
+  code: number;
+  message: string;
+  detail?: string;
+}
+
+export const ADMIN_EMAIL_VERIFICATION_ERROR_CODE = {
+  INVALID_REQUEST: 2002, // 400: 올바르지 않은 요청 값입니다.
+  TOO_MANY_REQUESTS: 7104, // 429: 인증 코드는 60초 후 재요청 가능합니다.
+  REQUEST_NOT_FOUND: 7000, // 400: 인증 요청이 존재하지 않습니다.
+} as const;
 
 // 7. 홈 화면 출력 요청
 // 홈 화면 출력 요청 바디 없음

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+const ANIMATION_MS = 420;
+/** 주소창 등 작은 뷰포트 변화는 키보드로 보지 않음 */
+const KEYBOARD_THRESHOLD_PX = 80;
+
+type BottomSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: ReactNode;
+  children: ReactNode;
+  /** 시트 패널 커스텀 클래스 */
+  sheetClassName?: string;
+  /** 배경 클릭 시 닫기 (기본 true) */
+  closeOnOverlayClick?: boolean;
+  /** 우측 상단 닫기 버튼 표시 (기본 true) */
+  showCloseButton?: boolean;
+};
+
+const isTouchEnvironment = () => {
+  if (typeof window === "undefined") return false;
+  return navigator.maxTouchPoints > 0 || "ontouchstart" in window;
+};
+
+const isTextField = (target: EventTarget | null) =>
+  target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+
+const getKeyboardOffset = () => {
+  const visualViewport = window.visualViewport;
+  if (!visualViewport) return 0;
+
+  const covered = Math.max(
+    0,
+    window.innerHeight - visualViewport.height - visualViewport.offsetTop,
+  );
+  return covered > KEYBOARD_THRESHOLD_PX ? covered : 0;
+};
+
+/**
+ * 화면 하단에서 올라오는 공통 바텀시트.
+ * 이메일 변경, 비밀번호 인증 등 다양한 콘텐츠를 children으로 조합해 사용한다.
+ */
+const BottomSheet = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+  children,
+  sheetClassName = "",
+  closeOnOverlayClick = true,
+  showCloseButton = true,
+}: BottomSheetProps) => {
+  const [shouldRender, setShouldRender] = useState(isOpen);
+  const [isVisible, setIsVisible] = useState(false);
+  const [keyboardOffset, setKeyboardOffset] = useState(0);
+  const [hasInputFocus, setHasInputFocus] = useState(false);
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRender(true);
+      const frameId = window.requestAnimationFrame(() => {
+        setIsVisible(true);
+      });
+      return () => window.cancelAnimationFrame(frameId);
+    }
+
+    setIsVisible(false);
+    setKeyboardOffset(0);
+    setHasInputFocus(false);
+    const timerId = window.setTimeout(() => {
+      setShouldRender(false);
+    }, ANIMATION_MS);
+    return () => window.clearTimeout(timerId);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!shouldRender) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [shouldRender]);
+
+  useEffect(() => {
+    if (!shouldRender) return;
+
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (!isTextField(event.target)) return;
+
+      setHasInputFocus(true);
+
+      const target = event.target as HTMLInputElement | HTMLTextAreaElement;
+      window.setTimeout(() => {
+        target.scrollIntoView({
+          block: "center",
+          behavior: "smooth",
+        });
+      }, 100);
+    };
+
+    const handleFocusOut = (event: FocusEvent) => {
+      if (!isTextField(event.target)) return;
+
+      // 시트 안 다른 입력으로 포커스가 이동하는 경우는 유지
+      const nextTarget = event.relatedTarget;
+      if (nextTarget instanceof Node && sheet.contains(nextTarget)) {
+        return;
+      }
+      setHasInputFocus(false);
+      setKeyboardOffset(0);
+    };
+
+    sheet.addEventListener("focusin", handleFocusIn);
+    sheet.addEventListener("focusout", handleFocusOut);
+    return () => {
+      sheet.removeEventListener("focusin", handleFocusIn);
+      sheet.removeEventListener("focusout", handleFocusOut);
+    };
+  }, [shouldRender]);
+
+  useEffect(() => {
+    if (!shouldRender || !isVisible) return;
+    if (!isTouchEnvironment() || !hasInputFocus) {
+      setKeyboardOffset(0);
+      return;
+    }
+
+    const updateKeyboardOffset = () => {
+      if (!isTouchEnvironment() || !hasInputFocus) {
+        setKeyboardOffset(0);
+        return;
+      }
+      setKeyboardOffset(getKeyboardOffset());
+    };
+
+    updateKeyboardOffset();
+
+    const visualViewport = window.visualViewport;
+    visualViewport?.addEventListener("resize", updateKeyboardOffset);
+    visualViewport?.addEventListener("scroll", updateKeyboardOffset);
+    window.addEventListener("resize", updateKeyboardOffset);
+
+    return () => {
+      visualViewport?.removeEventListener("resize", updateKeyboardOffset);
+      visualViewport?.removeEventListener("scroll", updateKeyboardOffset);
+      window.removeEventListener("resize", updateKeyboardOffset);
+    };
+  }, [shouldRender, isVisible, hasInputFocus]);
+
+  if (!shouldRender) return null;
+
+  const modalRoot = document.getElementById("modal-root");
+  if (!modalRoot) return null;
+
+  const maxHeight =
+    keyboardOffset > 0
+      ? `calc(100dvh - ${keyboardOffset}px)`
+      : "100dvh";
+
+  return createPortal(
+    <div className="fixed inset-0 z-[999] flex items-end justify-center">
+      <div
+        className={`absolute inset-0 bg-[#919191] transition-opacity duration-420 ${
+          isVisible ? "opacity-[0.38]" : "opacity-0"
+        }`}
+        onClick={closeOnOverlayClick ? onClose : undefined}
+        aria-hidden
+      />
+
+      <div
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        style={{
+          marginBottom: keyboardOffset,
+          maxHeight,
+        }}
+        className={`relative z-[1000] flex w-full max-w-[402px] flex-col overflow-hidden rounded-t-[24px] bg-neutral-white shadow-card transition-[margin-bottom,max-height] duration-200 ease-out ${
+          isVisible
+            ? "animate-bottom-sheet-up"
+            : isOpen
+              ? "translate-y-full"
+              : "animate-bottom-sheet-down"
+        } ${sheetClassName}`}
+      >
+        {showCloseButton && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute top-6 right-[22px] z-[1] flex size-3 cursor-pointer items-center justify-center"
+            aria-label="닫기"
+          >
+            <img src="/icons/X.svg" alt="" className="size-3" />
+          </button>
+        )}
+
+        {(title || description) && (
+          <div className="flex shrink-0 flex-col items-center gap-1 px-8 pt-9 font-[Pretendard]">
+            {title && (
+              <p className="text-center text-20px font-semibold leading-[140%] text-secondary-1">
+                {title}
+              </p>
+            )}
+            {description && (
+              <div className="text-center text-12px font-normal leading-[130%] text-primary">
+                {description}
+              </div>
+            )}
+          </div>
+        )}
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-8 pt-9 pb-[max(2.5rem,env(safe-area-inset-bottom))]">
+          {children}
+        </div>
+      </div>
+    </div>,
+    modalRoot,
+  );
+};
+
+export default BottomSheet;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -23,7 +23,7 @@ export const Modal = ({
   if (!isOpen) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[999] flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[1100] flex items-center justify-center p-4">
       {/* 배경 */}
       <div
         className="absolute inset-0 bg-[#919191] opacity-[0.38] "

--- a/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
@@ -2,12 +2,16 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from "react";
+import axios from "axios";
 import BottomSheet from "../../../BottomSheet";
 import CommonInput from "../../../CommonInput";
 import Button from "../../../Button";
 import EmailChangeExitConfirmModal from "./EmailChangeExitConfirmModal";
+import { useSendAdminEmailCode } from "../../../../hooks/queries/useAuthQueries";
+import type { AdminEmailVerificationErrorResponse } from "../../../../api/auth/auth.type";
 
 export type EmailChangeBottomSheetHandle = {
   /** 종료 확인 모달을 연다 (Header 뒤로가기 등 외부 이탈용) */
@@ -39,6 +43,10 @@ const EmailChangeBottomSheet = forwardRef<
   const [isTimerActive, setIsTimerActive] = useState(false);
   const [hasRequestedCode, setHasRequestedCode] = useState(false);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
+  /** 시트 닫힘/재전송 시 in-flight 콜백을 무효화 */
+  const sendRequestIdRef = useRef(0);
+
+  const { mutate: sendCode, isPending: isSendingCode } = useSendAdminEmailCode();
 
   const handleRequestClose = () => {
     setIsExitModalOpen(true);
@@ -50,6 +58,7 @@ const EmailChangeBottomSheet = forwardRef<
 
   useEffect(() => {
     if (!isOpen) {
+      sendRequestIdRef.current += 1;
       setNewEmail("");
       setAuthCode("");
       setTimeLeft(0);
@@ -78,17 +87,41 @@ const EmailChangeBottomSheet = forwardRef<
   };
 
   const handleSendCode = () => {
-    if (!newEmail.trim()) {
+    const email = newEmail.trim();
+    if (!email) {
       alert("변경할 이메일을 입력해주세요.");
       return;
     }
 
-    // TODO: 이메일 변경용 인증번호 전송 API 연동
-    setHasRequestedCode(true);
-    setTimeLeft(600);
-    setIsTimerActive(true);
-    setAuthCode("");
-    alert("이메일로 인증 코드가 전송되었습니다.");
+    const requestId = ++sendRequestIdRef.current;
+
+    sendCode(
+      { email, purpose: "EMAIL_CHANGE" },
+      {
+        onSuccess: (data) => {
+          // 시트 닫힘/재전송으로 무효화된 응답은 무시
+          if (requestId !== sendRequestIdRef.current) return;
+          setHasRequestedCode(true);
+          setTimeLeft(data.expiresInSeconds);
+          setIsTimerActive(true);
+          setAuthCode("");
+          alert("이메일로 인증 코드가 전송되었습니다.");
+        },
+        onError: (error) => {
+          if (requestId !== sendRequestIdRef.current) return;
+          if (axios.isAxiosError(error)) {
+            const data = error.response?.data as
+              | AdminEmailVerificationErrorResponse
+              | undefined;
+            if (data?.message) {
+              alert(data.message);
+              return;
+            }
+          }
+          alert("인증 코드 전송에 실패했습니다. 다시 시도해주세요.");
+        },
+      },
+    );
   };
 
   const handleVerifyCode = () => {
@@ -133,9 +166,13 @@ const EmailChangeBottomSheet = forwardRef<
               size="sm"
               className="h-11.5 w-25 shrink-0 rounded-xl text-14px font-semibold"
               onClick={handleSendCode}
-              disabled={!newEmail.trim() || isTimerActive}
+              disabled={!newEmail.trim() || isTimerActive || isSendingCode}
             >
-              {hasRequestedCode ? "재전송" : "인증번호 전송"}
+              {isSendingCode
+                ? "전송 중..."
+                : hasRequestedCode
+                  ? "재전송"
+                  : "인증번호 전송"}
             </Button>
           </div>
 

--- a/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
@@ -1,0 +1,186 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+import BottomSheet from "../../../BottomSheet";
+import CommonInput from "../../../CommonInput";
+import Button from "../../../Button";
+import EmailChangeExitConfirmModal from "./EmailChangeExitConfirmModal";
+
+export type EmailChangeBottomSheetHandle = {
+  /** 종료 확인 모달을 연다 (Header 뒤로가기 등 외부 이탈용) */
+  requestClose: () => void;
+};
+
+type EmailChangeBottomSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  /** 인증 완료 시 변경된 이메일 */
+  onVerified?: (email: string) => void;
+};
+
+const formatTime = (seconds: number) => {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = (seconds % 60).toString().padStart(2, "0");
+  return `${m}:${s}`;
+};
+
+const EmailChangeBottomSheet = forwardRef<
+  EmailChangeBottomSheetHandle,
+  EmailChangeBottomSheetProps
+>(({ isOpen, onClose, onVerified }, ref) => {
+  const [newEmail, setNewEmail] = useState("");
+  const [authCode, setAuthCode] = useState("");
+  const [timeLeft, setTimeLeft] = useState(0);
+  const [isTimerActive, setIsTimerActive] = useState(false);
+  const [hasRequestedCode, setHasRequestedCode] = useState(false);
+  const [isExitModalOpen, setIsExitModalOpen] = useState(false);
+
+  const handleRequestClose = () => {
+    setIsExitModalOpen(true);
+  };
+
+  useImperativeHandle(ref, () => ({
+    requestClose: handleRequestClose,
+  }));
+
+  useEffect(() => {
+    if (!isOpen) {
+      setNewEmail("");
+      setAuthCode("");
+      setTimeLeft(0);
+      setIsTimerActive(false);
+      setHasRequestedCode(false);
+      setIsExitModalOpen(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isTimerActive || timeLeft <= 0) {
+      if (timeLeft <= 0) setIsTimerActive(false);
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setTimeLeft((prev) => prev - 1);
+    }, 1000);
+
+    return () => window.clearInterval(timerId);
+  }, [isTimerActive, timeLeft]);
+
+  const handleConfirmExit = () => {
+    setIsExitModalOpen(false);
+    onClose();
+  };
+
+  const handleSendCode = () => {
+    if (!newEmail.trim()) {
+      alert("변경할 이메일을 입력해주세요.");
+      return;
+    }
+
+    // TODO: 이메일 변경용 인증번호 전송 API 연동
+    setHasRequestedCode(true);
+    setTimeLeft(600);
+    setIsTimerActive(true);
+    setAuthCode("");
+    alert("이메일로 인증 코드가 전송되었습니다.");
+  };
+
+  const handleVerifyCode = () => {
+    if (!authCode.trim()) {
+      alert("인증번호를 입력해주세요.");
+      return;
+    }
+
+    // TODO: 이메일 변경용 인증번호 확인 API 연동
+    onVerified?.(newEmail.trim());
+    onClose();
+  };
+
+  const canConfirm =
+    isTimerActive && timeLeft > 0 && authCode.trim().length > 0;
+
+  return (
+    <>
+      <BottomSheet
+        isOpen={isOpen}
+        onClose={handleRequestClose}
+        title="이메일 변경"
+        description="변경 시 이메일 인증이 필요해요"
+        sheetClassName="h-[612px] max-h-full"
+      >
+        <div className="flex w-full flex-col gap-2.5 font-[Pretendard] text-neutral-gray-1">
+          <p className="px-0.5 text-14px font-bold">이메일</p>
+
+          <div className="flex w-full items-center gap-1">
+            <div className="min-w-0 flex-1">
+              <CommonInput
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                placeholder="변경할 이메일을 입력해주세요"
+                className="h-12 max-w-none rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] placeholder:text-neutral-gray-3"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              className="h-11.5 w-25 shrink-0 rounded-xl text-14px font-semibold"
+              onClick={handleSendCode}
+              disabled={!newEmail.trim() || isTimerActive}
+            >
+              {hasRequestedCode ? "재전송" : "인증번호 전송"}
+            </Button>
+          </div>
+
+          <div className="relative flex w-full items-center gap-1">
+            <div className="relative min-w-0 flex-1">
+              <CommonInput
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={authCode}
+                onChange={(e) => setAuthCode(e.target.value.replace(/\D/g, ""))}
+                placeholder="인증번호 입력"
+                disabled={!isTimerActive}
+                className="h-12 max-w-none rounded-xl px-3.5 pr-14 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] placeholder:text-neutral-gray-3"
+              />
+              {isTimerActive && timeLeft > 0 && (
+                <span className="pointer-events-none absolute top-1/2 right-3.5 -translate-y-1/2 text-14px text-secondary-2">
+                  {formatTime(timeLeft)}
+                </span>
+              )}
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              className="h-11.5 w-25 shrink-0 rounded-xl text-14px font-semibold"
+              onClick={handleVerifyCode}
+              disabled={!canConfirm}
+            >
+              인증번호 확인
+            </Button>
+          </div>
+        </div>
+      </BottomSheet>
+
+      <EmailChangeExitConfirmModal
+        isOpen={isExitModalOpen}
+        onClose={() => setIsExitModalOpen(false)}
+        onConfirmExit={handleConfirmExit}
+      />
+    </>
+  );
+});
+
+EmailChangeBottomSheet.displayName = "EmailChangeBottomSheet";
+
+export default EmailChangeBottomSheet;

--- a/src/components/modals/admin/account/EmailChangeExitConfirmModal.tsx
+++ b/src/components/modals/admin/account/EmailChangeExitConfirmModal.tsx
@@ -1,0 +1,60 @@
+import { Modal } from "../../../Modal";
+import Button from "../../../Button";
+
+type EmailChangeExitConfirmModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirmExit: () => void;
+};
+
+const EmailChangeExitConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirmExit,
+}: EmailChangeExitConfirmModalProps) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      showTitle={false}
+      showCloseButton={false}
+      modalClassName="!w-[338px] !rounded-[24px] !px-4 !pt-10 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+    >
+      <div className="flex w-full flex-col items-center font-[Pretendard]">
+        <div className="flex min-h-[98px] flex-col items-center justify-center gap-3 px-2">
+          <p className="text-center text-20px font-semibold leading-[140%] text-secondary-1">
+            이메일 변경을 종료하시겠어요?
+          </p>
+          <p className="text-center text-14px font-normal leading-[140%] text-primary">
+            지금 나가시면
+            <br />
+            작성한 내용이 저장되지 않아요!
+          </p>
+        </div>
+
+        <div className="mt-6 flex h-12 w-full gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px shadow-[0_0_4px_rgba(181,244,255,0.5)]"
+            onClick={onConfirmExit}
+          >
+            나가기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default EmailChangeExitConfirmModal;

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -10,6 +10,7 @@ import {
   requestWithdraw,
   requestLoadHome,
   requestAdminProfile,
+  sendAdminEmailCode,
 } from "../../api/auth/auth.api";
 
 //
@@ -163,5 +164,20 @@ export const useAdminProfile = (options?: { enabled?: boolean }) => {
     queryFn: requestAdminProfile,
     retry: false,
     enabled: options?.enabled ?? true,
+  });
+};
+
+//
+// 7-1. 관리자 이메일 인증 코드 발송 요청
+//
+export const useSendAdminEmailCode = () => {
+  return useMutation({
+    mutationFn: sendAdminEmailCode,
+    onSuccess: () => {
+      console.log("관리자 이메일 인증 코드 발송 성공");
+    },
+    onError: (error) => {
+      console.error("관리자 이메일 인증 코드 발송 실패:", error);
+    },
   });
 };

--- a/src/index.css
+++ b/src/index.css
@@ -126,4 +126,28 @@
 
   /* 보더 컬러 */
   --color-menu-border: rgba(118, 173, 255, 0.1);
+
+  --animate-bottom-sheet-up: bottom-sheet-up 420ms cubic-bezier(0.32, 0.72, 0, 1)
+    both;
+  --animate-bottom-sheet-down: bottom-sheet-down 420ms cubic-bezier(0.32, 0.72, 0, 1)
+    both;
+  --duration-420: 420ms;
+
+  @keyframes bottom-sheet-up {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes bottom-sheet-down {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(100%);
+    }
+  }
 }

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -164,7 +164,7 @@ const AccountPage = () => {
           </div>
           <button
             type="button"
-            onClick={() => alert("개발 예정입니다.")}
+            onClick={() => navigate("/profile")}
             className="w-45 h-9.75 border border-primary shadow-primary rounded-[23.164px] hover:bg-bg-pale cursor-pointer"
           >
             <p className="text-center text-14px text-primary font-bold">

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -1,18 +1,46 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import CommonInput from "../../components/CommonInput";
 import Button from "../../components/Button";
+import ConfirmModal from "../../components/modals/ConfirmModal";
+import EmailChangeBottomSheet, {
+  type EmailChangeBottomSheetHandle,
+} from "../../components/modals/admin/account/EmailChangeBottomSheet";
 import { getPasswordValidationError } from "../../utils/passwordValidation";
-import AdminAccountCommonFields from "../../components/admin/AdminAccountCommonFields";
+import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
 
 const ProfileEditPage = () => {
+  const navigate = useNavigate();
+  const { data: profile } = useAdminProfile();
+  const emailSheetRef = useRef<EmailChangeBottomSheetHandle>(null);
+
   const [organizationName, setOrganizationName] = useState("");
   const [email, setEmail] = useState("");
-  const [authCode, setAuthCode] = useState("");
   const [password, setPassword] = useState("");
   const [passwordCheck, setPasswordCheck] = useState("");
   const [adminCode, setAdminCode] = useState("");
+  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
+  const [isEmailSheetOpen, setIsEmailSheetOpen] = useState(false);
+
+  useEffect(() => {
+    if (!profile) return;
+    setOrganizationName(profile.organizationName ?? "");
+    setEmail(profile.email ?? "");
+  }, [profile]);
+
+  const handleEditEmail = () => {
+    setIsEmailSheetOpen(true);
+  };
+
+  const handleHeaderBack = () => {
+    if (isEmailSheetOpen) {
+      emailSheetRef.current?.requestClose();
+      return;
+    }
+    navigate("/account");
+  };
 
   const handleSubmit = () => {
     if (!organizationName.trim()) return alert("이름(단체명)을 입력해주세요.");
@@ -21,7 +49,7 @@ const ProfileEditPage = () => {
     const passwordError = getPasswordValidationError(password);
     if (passwordError) return alert(passwordError);
 
-    if (!passwordCheck) return alert("비밀번호 확인 입력을 진행해주세요.");
+    if (!passwordCheck) return alert("비밀번호 확인을 위해 재입력해주세요.");
     if (password !== passwordCheck) {
       return alert("비밀번호가 일치하지 않습니다. 다시 입력해주세요.");
     }
@@ -31,84 +59,149 @@ const ProfileEditPage = () => {
       return alert("관리자 코드는 6자리 숫자여야 합니다.");
     }
 
-    alert("입력값 검증이 완료되었습니다.");
+    // TODO: 개인정보 수정 API 연동
+    setIsCompleteModalOpen(true);
   };
 
   return (
     <Layout>
-      <Header pageName="개인정보 수정" backTo="/account" />
-      <div className="flex flex-col items-center w-full gap-6 pt-8 px-8 ">
-        {/* 1. 이름(단체명) 입력필드 */}
-        <div className="flex flex-col w-full gap-2">
-          <div className="flex gap-0.5">
-            <p className=" text-14px font-bold">이름(단체명)</p>
-            <p className="text-14px text-primary">*</p>
+      <Header pageName="개인정보 수정" onBackClick={handleHeaderBack} />
+
+      <div className="flex w-full flex-col items-start gap-6 px-8 pt-8.75 font-[Pretendard] text-neutral-gray-1">
+        {/* 이름(단체명) */}
+        <div className="flex w-full flex-col gap-2.5">
+          <div className="flex items-center">
+            <p className="px-0.5 text-14px font-bold">이름(단체명)</p>
+            <p className="text-14px font-bold text-primary">*</p>
           </div>
           <CommonInput
             type="text"
             value={organizationName}
             onChange={(e) => setOrganizationName(e.target.value)}
-            placeholder="한국대 도서관자치위원회"
-            className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
+            placeholder="한국대 총학생회"
+            className="h-12 rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
           />
         </div>
 
-        {/* 2. 이메일 인증 관련 입력 필드 */}
-        <div className="flex flex-col w-full gap-2.5">
-          <div className="flex gap-0.5">
-            <p className=" text-14px font-bold ">이메일</p>
-            <p className="text-14px text-primary">*</p>
+        {/* 이메일 */}
+        <div className="flex w-full flex-col gap-2.5">
+          <div className="flex items-center">
+            <p className="px-0.5 text-14px font-bold">이메일</p>
+            <p className="text-14px font-bold text-primary">*</p>
           </div>
-          <div className="flex justify-between items-center gap-1">
-            <CommonInput
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="retrivr@gmail.com"
-              className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
-            />
-            <Button variant="primary" size="sm" className="w-25 h-11.5">
-              인증번호 전송
+          <div className="flex w-full items-center gap-1">
+            <div className="min-w-0 flex-1">
+              <CommonInput
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="retrivr@gmail.com"
+                className="h-12 max-w-none rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] placeholder:text-neutral-gray-3"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              className="h-11.5 w-25 shrink-0 rounded-xl text-14px font-semibold"
+              onClick={handleEditEmail}
+            >
+              수정하기
             </Button>
           </div>
-          <div className="relative flex justify-between items-center gap-1">
-            <CommonInput
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]{6}"
-              maxLength={6}
-              value={authCode}
-              onChange={(e) => setAuthCode(e.target.value)}
-              placeholder="인증번호 입력"
-              className="placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] "
-            />
-
-            <Button variant="gray" size="sm" className="w-25 h-11.5">
-              인증번호 확인
-            </Button>
-          </div>
+          <p className="px-0.5 text-12px font-normal leading-[130%] text-secondary-2">
+            이메일 변경 시 새로 인증이 필요해요
+          </p>
         </div>
 
-        <AdminAccountCommonFields
-          variant="profileEdit"
-          includeOrganizationName={false}
-          organizationName={organizationName}
-          onOrganizationNameChange={setOrganizationName}
-          password={password}
-          onPasswordChange={setPassword}
-          passwordCheck={passwordCheck}
-          onPasswordCheckChange={setPasswordCheck}
-          adminCode={adminCode}
-          onAdminCodeChange={setAdminCode}
-        />
+        {/* 비밀번호 */}
+        <div className="flex w-full flex-col gap-2.5">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center">
+              <p className="px-0.5 text-14px font-bold">비밀번호</p>
+              <p className="text-14px font-bold text-primary">*</p>
+            </div>
+            <p className="px-0.5 text-12px font-normal leading-[130%] text-neutral-gray-3">
+              영문자, 숫자, 특수문자를 포함한 8자 이상으로 설정해주세요.
+            </p>
+          </div>
+          <CommonInput
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호 입력"
+            className="h-12 rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+          />
+        </div>
+
+        {/* 비밀번호 재입력 */}
+        <div className="flex w-full flex-col gap-2.5">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center">
+              <p className="px-0.5 text-14px font-bold">비밀번호 재입력</p>
+              <p className="text-14px font-bold text-primary">*</p>
+            </div>
+            <p className="px-0.5 text-12px font-normal leading-[130%] text-neutral-gray-3">
+              비밀번호 확인을 위해 재입력해주세요
+            </p>
+          </div>
+          <CommonInput
+            type="password"
+            value={passwordCheck}
+            onChange={(e) => setPasswordCheck(e.target.value)}
+            placeholder="비밀번호 재입력"
+            className="h-12 rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+          />
+        </div>
+
+        {/* 관리자 코드 */}
+        <div className="flex w-full flex-col gap-2.5">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center">
+              <p className="px-0.5 text-14px font-bold">관리자 코드</p>
+              <p className="text-14px font-bold text-primary">*</p>
+            </div>
+            <p className="px-0.5 text-12px font-normal leading-[130%] text-neutral-gray-3">
+              물품 관리 등 중요할 때 쓰이는 코드로, 숫자만 입력가능해요.
+            </p>
+          </div>
+          <CommonInput
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            maxLength={6}
+            value={adminCode}
+            onChange={(e) => setAdminCode(e.target.value.replace(/\D/g, ""))}
+            placeholder="관리자 코드 입력"
+            className="h-12 rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%]"
+          />
+        </div>
       </div>
 
-      {/* 5. 확인 버튼 */}
-      <div className="w-full flex flex-col items-center mt-auto mb-10">
-        <Button variant="primary" size="lg" onClick={handleSubmit}>
+      <div className="mt-auto mb-10 flex w-full flex-col items-center px-8">
+        <Button
+          variant="primary"
+          size="lg"
+          className="h-12.5 w-full max-w-[338px] rounded-[23.164px] shadow-primary"
+          onClick={handleSubmit}
+        >
           확인
         </Button>
       </div>
+
+      <ConfirmModal
+        isOpen={isCompleteModalOpen}
+        onClose={() => setIsCompleteModalOpen(false)}
+        message="개인정보 수정이 완료되었어요"
+        confirmText="확인"
+        onConfirm={() => navigate("/account")}
+      />
+      <EmailChangeBottomSheet
+        ref={emailSheetRef}
+        isOpen={isEmailSheetOpen}
+        onClose={() => setIsEmailSheetOpen(false)}
+        onVerified={(nextEmail) => setEmail(nextEmail)}
+      />
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- `POST /api/admin/v1/email/verification` 발송 API/타입/훅 추가 (`purpose: EMAIL_CHANGE`)
- `EmailChangeBottomSheet`에 발송 연동 및 400/429 메시지 표시
- 시트 이탈·재전송 시 in-flight 콜백 무효화
- 개인정보 수정 UI(`feature/profile-edit-page`)를 develop 기반에 병합

## Test plan
- [x] 브라우저: `/profile` → 이메일 수정 → `retrivr.frontend@gmail.com`으로 인증번호 전송 → 200 + 타이머 시작
- [ ] 메일함에서 인증코드 수신 확인


Made with [Cursor](https://cursor.com)