### PR TITLE
[RTR-302] 관리자 이메일 인증코드 검증 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -15,6 +15,8 @@ import type {
   AdminProfileResponse,
   SendAdminEmailCodeRequest,
   SendAdminEmailCodeResponse,
+  VerifyAdminEmailCodeRequest,
+  VerifyAdminEmailCodeResponse,
   LoadHomeResponse,
   LogoutResponse,
   WithdrawRequest,
@@ -152,6 +154,19 @@ export const sendAdminEmailCode = async (
 ): Promise<SendAdminEmailCodeResponse> => {
   const response = await apiClient.post<SendAdminEmailCodeResponse>(
     "/api/admin/v1/email/verification",
+    data,
+  );
+  return response.data;
+};
+
+//
+// 7-2. 관리자 이메일 인증 코드 검증 API (POST)
+// 엔드포인트 : "/api/admin/v1/email/verification/verify"
+export const verifyAdminEmailCode = async (
+  data: VerifyAdminEmailCodeRequest,
+): Promise<VerifyAdminEmailCodeResponse> => {
+  const response = await apiClient.post<VerifyAdminEmailCodeResponse>(
+    "/api/admin/v1/email/verification/verify",
     data,
   );
   return response.data;

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -160,6 +160,20 @@ export interface AdminProfileResponse {
 export type SendAdminEmailCodeRequest = SendEmailCodeRequest;
 export type SendAdminEmailCodeResponse = SendEmailCodeResponse;
 
+// 6-2. 관리자 이메일 인증 코드 검증
+// 엔드포인트: "/api/admin/v1/email/verification/verify" (POST)
+export interface VerifyAdminEmailCodeRequest {
+  email: string;
+  purpose: EmailVerificationPurpose; // 이메일 변경: EMAIL_CHANGE
+  code: string;
+}
+
+export interface VerifyAdminEmailCodeResponse {
+  tokenType: string;
+  token: string;
+  expiresInSeconds: number;
+}
+
 // 관리자 이메일 인증 공통 에러 응답 (400/429 등)
 export interface AdminEmailVerificationErrorResponse {
   status: string; // 예: "400 BAD_REQUEST", "429 TOO_MANY_REQUESTS"

--- a/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
@@ -10,7 +10,10 @@ import BottomSheet from "../../../BottomSheet";
 import CommonInput from "../../../CommonInput";
 import Button from "../../../Button";
 import EmailChangeExitConfirmModal from "./EmailChangeExitConfirmModal";
-import { useSendAdminEmailCode } from "../../../../hooks/queries/useAuthQueries";
+import {
+  useSendAdminEmailCode,
+  useVerifyAdminEmailCode,
+} from "../../../../hooks/queries/useAuthQueries";
 import type { AdminEmailVerificationErrorResponse } from "../../../../api/auth/auth.type";
 
 export type EmailChangeBottomSheetHandle = {
@@ -18,11 +21,16 @@ export type EmailChangeBottomSheetHandle = {
   requestClose: () => void;
 };
 
+export type EmailChangeVerifiedPayload = {
+  email: string;
+  token: string;
+};
+
 type EmailChangeBottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
-  /** 인증 완료 시 변경된 이메일 */
-  onVerified?: (email: string) => void;
+  /** 인증 완료 시 변경된 이메일 + 검증 토큰 */
+  onVerified?: (payload: EmailChangeVerifiedPayload) => void;
 };
 
 const formatTime = (seconds: number) => {
@@ -43,10 +51,13 @@ const EmailChangeBottomSheet = forwardRef<
   const [isTimerActive, setIsTimerActive] = useState(false);
   const [hasRequestedCode, setHasRequestedCode] = useState(false);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
-  /** 시트 닫힘/재전송 시 in-flight 콜백을 무효화 */
+  /** 시트 닫힘/재요청 시 in-flight 콜백을 무효화 */
   const sendRequestIdRef = useRef(0);
+  const verifyRequestIdRef = useRef(0);
 
   const { mutate: sendCode, isPending: isSendingCode } = useSendAdminEmailCode();
+  const { mutate: verifyCode, isPending: isVerifyingCode } =
+    useVerifyAdminEmailCode();
 
   const handleRequestClose = () => {
     setIsExitModalOpen(true);
@@ -59,6 +70,7 @@ const EmailChangeBottomSheet = forwardRef<
   useEffect(() => {
     if (!isOpen) {
       sendRequestIdRef.current += 1;
+      verifyRequestIdRef.current += 1;
       setNewEmail("");
       setAuthCode("");
       setTimeLeft(0);
@@ -94,6 +106,8 @@ const EmailChangeBottomSheet = forwardRef<
     }
 
     const requestId = ++sendRequestIdRef.current;
+    // 재전송 시 진행 중인 검증 콜백도 무효화
+    verifyRequestIdRef.current += 1;
 
     sendCode(
       { email, purpose: "EMAIL_CHANGE" },
@@ -125,18 +139,55 @@ const EmailChangeBottomSheet = forwardRef<
   };
 
   const handleVerifyCode = () => {
-    if (!authCode.trim()) {
+    const email = newEmail.trim();
+    const code = authCode.trim();
+    if (!code) {
       alert("인증번호를 입력해주세요.");
       return;
     }
+    if (!email) {
+      alert("변경할 이메일을 입력해주세요.");
+      return;
+    }
 
-    // TODO: 이메일 변경용 인증번호 확인 API 연동
-    onVerified?.(newEmail.trim());
-    onClose();
+    const requestId = ++verifyRequestIdRef.current;
+
+    verifyCode(
+      { email, purpose: "EMAIL_CHANGE", code },
+      {
+        onSuccess: (data) => {
+          if (requestId !== verifyRequestIdRef.current) return;
+          if (!data.token) {
+            alert("인증 토큰 발급에 실패했습니다. 다시 시도해주세요.");
+            return;
+          }
+          alert("이메일 인증이 완료되었습니다.");
+          setIsTimerActive(false);
+          onVerified?.({ email, token: data.token });
+          onClose();
+        },
+        onError: (error) => {
+          if (requestId !== verifyRequestIdRef.current) return;
+          if (axios.isAxiosError(error)) {
+            const data = error.response?.data as
+              | AdminEmailVerificationErrorResponse
+              | undefined;
+            if (data?.message) {
+              alert(data.message);
+              return;
+            }
+          }
+          alert("인증 코드 확인에 실패했습니다. 다시 시도해주세요.");
+        },
+      },
+    );
   };
 
   const canConfirm =
-    isTimerActive && timeLeft > 0 && authCode.trim().length > 0;
+    isTimerActive &&
+    timeLeft > 0 &&
+    authCode.trim().length > 0 &&
+    !isVerifyingCode;
 
   return (
     <>
@@ -203,7 +254,7 @@ const EmailChangeBottomSheet = forwardRef<
               onClick={handleVerifyCode}
               disabled={!canConfirm}
             >
-              인증번호 확인
+              {isVerifyingCode ? "확인 중..." : "인증번호 확인"}
             </Button>
           </div>
         </div>

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -11,6 +11,7 @@ import {
   requestLoadHome,
   requestAdminProfile,
   sendAdminEmailCode,
+  verifyAdminEmailCode,
 } from "../../api/auth/auth.api";
 
 //
@@ -178,6 +179,21 @@ export const useSendAdminEmailCode = () => {
     },
     onError: (error) => {
       console.error("관리자 이메일 인증 코드 발송 실패:", error);
+    },
+  });
+};
+
+//
+// 7-2. 관리자 이메일 인증 코드 검증 요청
+//
+export const useVerifyAdminEmailCode = () => {
+  return useMutation({
+    mutationFn: verifyAdminEmailCode,
+    onSuccess: () => {
+      console.log("관리자 이메일 인증 코드 검증 성공");
+    },
+    onError: (error) => {
+      console.error("관리자 이메일 인증 코드 검증 실패:", error);
     },
   });
 };

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -23,6 +23,8 @@ const ProfileEditPage = () => {
   const [adminCode, setAdminCode] = useState("");
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
   const [isEmailSheetOpen, setIsEmailSheetOpen] = useState(false);
+  /** 이메일 변경 인증 성공 시 발급되는 토큰 (프로필 PATCH용) */
+  const [emailVerificationToken, setEmailVerificationToken] = useState("");
 
   useEffect(() => {
     if (!profile) return;
@@ -57,6 +59,14 @@ const ProfileEditPage = () => {
     if (!adminCode.trim()) return alert("관리자 코드를 입력해주세요.");
     if (!/^\d{6}$/.test(adminCode)) {
       return alert("관리자 코드는 6자리 숫자여야 합니다.");
+    }
+
+    if (
+      profile?.email &&
+      email.trim() !== profile.email &&
+      !emailVerificationToken
+    ) {
+      return alert("이메일 변경 시 인증이 필요해요. 이메일 수정을 완료해주세요.");
     }
 
     // TODO: 개인정보 수정 API 연동
@@ -94,9 +104,12 @@ const ProfileEditPage = () => {
               <CommonInput
                 type="email"
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                readOnly
+                tabIndex={-1}
+                onFocus={(e) => e.currentTarget.blur()}
+                aria-readonly="true"
                 placeholder="retrivr@gmail.com"
-                className="h-12 max-w-none rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] placeholder:text-neutral-gray-3"
+                className="h-12 max-w-none cursor-default rounded-xl px-3.5 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] placeholder:text-neutral-gray-3 focus:ring-0"
               />
             </div>
             <Button
@@ -200,7 +213,10 @@ const ProfileEditPage = () => {
         ref={emailSheetRef}
         isOpen={isEmailSheetOpen}
         onClose={() => setIsEmailSheetOpen(false)}
-        onVerified={(nextEmail) => setEmail(nextEmail)}
+        onVerified={({ email: nextEmail, token }) => {
+          setEmail(nextEmail);
+          setEmailVerificationToken(token);
+        }}
       />
     </Layout>
   );


### PR DESCRIPTION
## Summary
- `POST /api/admin/v1/email/verification/verify` 검증 API/타입/훅 추가
- `EmailChangeBottomSheet` 검증 연동 및 토큰을 `ProfileEditPage`에 전달
- 메인 폼 이메일은 읽기 전용 — 인증 바텀시트로만 변경

## Test plan
- [x] 사용자 확인: API2 검증 플로우 정상 동작
- [x] 이메일 필드 수동 수정 불가


Made with [Cursor](https://cursor.com)