### PR TITLE
[RTR-302] 관리자 프로필 수정 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -17,6 +17,8 @@ import type {
   SendAdminEmailCodeResponse,
   VerifyAdminEmailCodeRequest,
   VerifyAdminEmailCodeResponse,
+  UpdateAdminProfileRequest,
+  UpdateAdminProfileResponse,
   LoadHomeResponse,
   LogoutResponse,
   WithdrawRequest,
@@ -167,6 +169,19 @@ export const verifyAdminEmailCode = async (
 ): Promise<VerifyAdminEmailCodeResponse> => {
   const response = await apiClient.post<VerifyAdminEmailCodeResponse>(
     "/api/admin/v1/email/verification/verify",
+    data,
+  );
+  return response.data;
+};
+
+//
+// 7-3. 관리자 프로필 수정 API (PATCH)
+// 엔드포인트 : "/api/admin/v1/profile"
+export const updateAdminProfile = async (
+  data: UpdateAdminProfileRequest,
+): Promise<UpdateAdminProfileResponse> => {
+  const response = await apiClient.patch<UpdateAdminProfileResponse>(
+    "/api/admin/v1/profile",
     data,
   );
   return response.data;

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -188,6 +188,32 @@ export const ADMIN_EMAIL_VERIFICATION_ERROR_CODE = {
   REQUEST_NOT_FOUND: 7000, // 400: 인증 요청이 존재하지 않습니다.
 } as const;
 
+// 6-3. 관리자 프로필 수정
+// 엔드포인트: "/api/admin/v1/profile" (PATCH)
+export interface UpdateAdminProfileRequest {
+  newEmail: string;
+  newPassword: string;
+  confirmPassword: string;
+  newOrganizationName: string;
+  newAdminCode: string;
+  /** 이메일 변경 인증 토큰 등 검증 토큰 (변경 시에만 전달) */
+  adminCodeVerificationToken?: string;
+}
+
+export type UpdateAdminProfileResponse = AdminProfileResponse;
+
+export interface UpdateAdminProfileErrorResponse {
+  status: string; // 예: "400 BAD_REQUEST", "404 NOT_FOUND"
+  code: number;
+  message: string;
+  detail?: string;
+}
+
+export const UPDATE_ADMIN_PROFILE_ERROR_CODE = {
+  INVALID_REQUEST: 2002, // 400: 올바르지 않은 요청 값입니다.
+  ORGANIZATION_NOT_FOUND: 3004, // 404: 존재하지 않는 단체입니다.
+} as const;
+
 // 7. 홈 화면 출력 요청
 // 홈 화면 출력 요청 바디 없음
 

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   sendEmailCode,
   verifyEmailCode,
@@ -12,6 +12,7 @@ import {
   requestAdminProfile,
   sendAdminEmailCode,
   verifyAdminEmailCode,
+  updateAdminProfile,
 } from "../../api/auth/auth.api";
 
 //
@@ -194,6 +195,25 @@ export const useVerifyAdminEmailCode = () => {
     },
     onError: (error) => {
       console.error("관리자 이메일 인증 코드 검증 실패:", error);
+    },
+  });
+};
+
+//
+// 7-3. 관리자 프로필 수정 요청
+//
+export const useUpdateAdminProfile = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateAdminProfile,
+    onSuccess: () => {
+      console.log("관리자 프로필 수정 성공");
+      queryClient.invalidateQueries({ queryKey: ["adminProfile"] });
+      queryClient.invalidateQueries({ queryKey: ["home"] });
+    },
+    onError: (error) => {
+      console.error("관리자 프로필 수정 실패:", error);
     },
   });
 };

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import CommonInput from "../../components/CommonInput";
@@ -9,11 +10,17 @@ import EmailChangeBottomSheet, {
   type EmailChangeBottomSheetHandle,
 } from "../../components/modals/admin/account/EmailChangeBottomSheet";
 import { getPasswordValidationError } from "../../utils/passwordValidation";
-import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
+import {
+  useAdminProfile,
+  useUpdateAdminProfile,
+} from "../../hooks/queries/useAuthQueries";
+import type { UpdateAdminProfileErrorResponse } from "../../api/auth/auth.type";
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
   const { data: profile } = useAdminProfile();
+  const { mutate: updateProfile, isPending: isUpdating } =
+    useUpdateAdminProfile();
   const emailSheetRef = useRef<EmailChangeBottomSheetHandle>(null);
 
   const [organizationName, setOrganizationName] = useState("");
@@ -61,16 +68,48 @@ const ProfileEditPage = () => {
       return alert("관리자 코드는 6자리 숫자여야 합니다.");
     }
 
-    if (
-      profile?.email &&
-      email.trim() !== profile.email &&
-      !emailVerificationToken
-    ) {
+    const emailChanged = Boolean(
+      profile?.email && email.trim() !== profile.email,
+    );
+    if (emailChanged && !emailVerificationToken) {
       return alert("이메일 변경 시 인증이 필요해요. 이메일 수정을 완료해주세요.");
     }
 
-    // TODO: 개인정보 수정 API 연동
-    setIsCompleteModalOpen(true);
+    updateProfile(
+      {
+        newEmail: email.trim(),
+        newPassword: password,
+        confirmPassword: passwordCheck,
+        newOrganizationName: organizationName.trim(),
+        newAdminCode: adminCode.trim(),
+        ...(emailChanged && emailVerificationToken
+          ? { adminCodeVerificationToken: emailVerificationToken }
+          : {}),
+      },
+      {
+        onSuccess: (data) => {
+          setEmail(data.email);
+          setOrganizationName(data.organizationName);
+          setEmailVerificationToken("");
+          setPassword("");
+          setPasswordCheck("");
+          setAdminCode("");
+          setIsCompleteModalOpen(true);
+        },
+        onError: (error) => {
+          if (axios.isAxiosError(error)) {
+            const data = error.response?.data as
+              | UpdateAdminProfileErrorResponse
+              | undefined;
+            if (data?.message) {
+              alert(data.message);
+              return;
+            }
+          }
+          alert("개인정보 수정에 실패했습니다. 다시 시도해주세요.");
+        },
+      },
+    );
   };
 
   return (
@@ -197,8 +236,9 @@ const ProfileEditPage = () => {
           size="lg"
           className="h-12.5 w-full max-w-[338px] rounded-[23.164px] shadow-primary"
           onClick={handleSubmit}
+          disabled={isUpdating}
         >
-          확인
+          {isUpdating ? "저장 중..." : "확인"}
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary
- `PATCH /api/admin/v1/profile` API/타입/훅 추가
- `ProfileEditPage` 확인 버튼에 프로필 수정 mutation 연결
- 이메일 변경 시에만 `adminCodeVerificationToken`(이메일 인증 토큰) 전달
- 성공 시 `adminProfile`/`home` 쿼리 invalidate

## Test plan
- [ ] `/profile`에서 단체명/비밀번호/관리자코드 입력 후 확인 → 200 + 완료 모달
- [ ] 이메일 변경(인증 완료) 후 저장 시 토큰 포함 요청 확인
- [ ] 400/404 시 서버 message alert


Made with [Cursor](https://cursor.com)