### PR TITLE
[RTR-301] 회원 탈퇴 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -118,12 +118,19 @@ export const requestLogout = async (): Promise<LogoutResponse> => {
 //
 // 5-1. 회원 탈퇴 요청 API (POST)
 // 엔드포인트: "/api/admin/v1/account/withdraw"
+// 요청 바디: password, reasonCodes, otherReason?, agreedToWarning
+// 비밀번호는 별도 확인 API 없이 탈퇴 요청에 포함해 서버에서 검증한다.
 export const requestWithdraw = async (
   data: WithdrawRequest,
 ): Promise<WithdrawResponse> => {
   const response = await apiClient.post<WithdrawResponse>(
     "/api/admin/v1/account/withdraw",
-    data,
+    {
+      password: data.password,
+      reasonCodes: data.reasonCodes,
+      ...(data.otherReason ? { otherReason: data.otherReason } : {}),
+      agreedToWarning: data.agreedToWarning,
+    },
   );
   return response.data;
 };

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -114,8 +114,15 @@ export interface LogoutResponse {
 // 엔드포인트: "/api/admin/v1/account/withdraw"
 
 // 탈퇴 사유 코드 (서버 enum)
-// 확인된 값 외에도 추가될 수 있어 string 유니언으로 열어둔다
-export type WithdrawReasonCode = "ORG_CLOSED" | (string & {});
+export type WithdrawReasonCode =
+  | "ORG_CLOSED"
+  | "NO_LONGER_OPERATING_RENTAL"
+  | "MOVED_TO_OTHER_SERVICE"
+  | "PRIVACY_CONCERN"
+  | "SERVICE_UNSATISFIED"
+  | "MISSING_FEATURE"
+  | "LOW_USAGE"
+  | "OTHER";
 
 // 5-2-1. 회원 탈퇴 요청 바디
 export interface WithdrawRequest {

--- a/src/pages/admin/WithdrawPage.tsx
+++ b/src/pages/admin/WithdrawPage.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import Button from "../../components/Button";
@@ -7,8 +9,15 @@ import CustomCheckBox from "../../components/CustomCheckbox";
 import WithdrawExitConfirmModal from "../../components/modals/admin/account/WithdrawExitConfirmModal";
 import WithdrawPasswordMismatchModal from "../../components/modals/admin/account/WithdrawPasswordMismatchModal";
 import WithdrawCompleteModal from "../../components/modals/admin/account/WithdrawCompleteModal";
-import { useAdminProfile } from "../../hooks/queries/useAuthQueries";
-import type { WithdrawReasonCode } from "../../api/auth/auth.type";
+import {
+  useAdminProfile,
+  useWithdraw,
+} from "../../hooks/queries/useAuthQueries";
+import type {
+  WithdrawErrorResponse,
+  WithdrawReasonCode,
+} from "../../api/auth/auth.type";
+import { WITHDRAW_ERROR_CODE } from "../../api/auth/auth.type";
 
 const NOTICE_ITEMS = [
   {
@@ -45,6 +54,12 @@ const WITHDRAW_REASONS: { code: WithdrawReasonCode; label: string }[] = [
 type WithdrawStep = 1 | 2;
 type SlideDirection = "forward" | "back";
 
+const clearAdminSession = () => {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("orgId");
+};
+
 const StepIndicator = ({ step }: { step: WithdrawStep }) => {
   const circle = (n: WithdrawStep) => {
     const active = step === n;
@@ -76,7 +91,10 @@ const StepIndicator = ({ step }: { step: WithdrawStep }) => {
 
 const WithdrawPage = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { data: profile } = useAdminProfile();
+  const { mutate: withdraw, isPending: isWithdrawing } = useWithdraw();
+
   const [step, setStep] = useState<WithdrawStep>(1);
   const [slideDirection, setSlideDirection] =
     useState<SlideDirection>("forward");
@@ -96,7 +114,6 @@ const WithdrawPage = () => {
   const [otherReason, setOtherReason] = useState("");
 
   const [password, setPassword] = useState("");
-  const [isPasswordVerified, setIsPasswordVerified] = useState(false);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
   const [isPasswordMismatchOpen, setIsPasswordMismatchOpen] = useState(false);
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
@@ -108,6 +125,8 @@ const WithdrawPage = () => {
     if (selectedReasons.has("OTHER") && !otherReason.trim()) return false;
     return true;
   }, [agreedToWarning, selectedReasons, otherReason]);
+
+  const canWithdraw = password.trim().length > 0 && !isWithdrawing;
 
   const toggleReason = (code: WithdrawReasonCode) => {
     setSelectedReasons((prev) => {
@@ -122,22 +141,49 @@ const WithdrawPage = () => {
     });
   };
 
-  const handleVerifyPassword = () => {
-    // TODO: 비밀번호 확인 API 연동. 실패 시 불일치 모달 표시
+  const handleWithdraw = () => {
     if (!password.trim()) {
       setIsPasswordMismatchOpen(true);
       return;
     }
-    setIsPasswordVerified(true);
-  };
 
-  const handleWithdraw = () => {
-    if (!isPasswordVerified) {
-      alert("비밀번호를 먼저 확인해주세요.");
-      return;
-    }
-    // TODO: 탈퇴 API 연동. 성공 응답 시 완료 모달 표시
-    setIsCompleteModalOpen(true);
+    const reasonCodes = Array.from(selectedReasons);
+    withdraw(
+      {
+        password: password.trim(),
+        reasonCodes,
+        ...(selectedReasons.has("OTHER") && otherReason.trim()
+          ? { otherReason: otherReason.trim() }
+          : {}),
+        agreedToWarning,
+      },
+      {
+        onSuccess: () => {
+          clearAdminSession();
+          void queryClient.cancelQueries();
+          queueMicrotask(() => {
+            queryClient.clear();
+          });
+          setIsCompleteModalOpen(true);
+        },
+        onError: (error) => {
+          if (axios.isAxiosError(error)) {
+            const data = error.response?.data as
+              | WithdrawErrorResponse
+              | undefined;
+            if (data?.code === WITHDRAW_ERROR_CODE.PASSWORD_MISMATCH) {
+              setIsPasswordMismatchOpen(true);
+              return;
+            }
+            if (data?.message) {
+              alert(data.message);
+              return;
+            }
+          }
+          alert("회원 탈퇴에 실패했습니다. 다시 시도해주세요.");
+        },
+      },
+    );
   };
 
   return (
@@ -148,7 +194,6 @@ const WithdrawPage = () => {
         onBackClick={() => {
           if (step === 2) {
             goToStep(1);
-            setIsPasswordVerified(false);
             setPassword("");
             return;
           }
@@ -289,7 +334,7 @@ const WithdrawPage = () => {
             </>
           ) : (
             <>
-              {/* 비밀번호 재확인 */}
+              {/* 비밀번호 재확인 — 입력값을 탈퇴 요청 바디로 전달 */}
               <div className="mt-8 flex w-full max-w-[338px] flex-col gap-2.5">
                 <p className="flex items-center text-14px font-bold">
                   비밀번호 재확인
@@ -300,32 +345,13 @@ const WithdrawPage = () => {
                   {email || "이메일 불러오는 중…"}
                 </div>
 
-                <div className="flex items-center gap-1">
-                  <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => {
-                      setPassword(e.target.value);
-                      setIsPasswordVerified(false);
-                    }}
-                    placeholder="비밀번호 입력"
-                    className="h-12 w-[234px] shrink-0 rounded-xl bg-[#F8F9F9] px-3.5 text-14px font-normal text-neutral-gray-1 outline-none placeholder:text-neutral-gray-3"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleVerifyPassword}
-                    className="flex h-11.5 w-25 shrink-0 cursor-pointer items-center justify-center rounded-xl bg-primary text-14px font-semibold text-neutral-white hover:bg-secondary-2"
-                  >
-                    확인
-                  </button>
-                </div>
-
-                {isPasswordVerified && (
-                  <div className="flex items-center gap-1 text-12px font-normal leading-[140%] text-primary">
-                    <CustomCheckBox checked disabled />
-                    <span>비밀번호가 확인되었어요!</span>
-                  </div>
-                )}
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="비밀번호 입력"
+                  className="h-12 w-full rounded-xl bg-[#F8F9F9] px-3.5 text-14px font-normal text-neutral-gray-1 outline-none placeholder:text-neutral-gray-3"
+                />
               </div>
 
               <div className="mt-auto w-full max-w-[338px] pt-20">
@@ -333,10 +359,10 @@ const WithdrawPage = () => {
                   variant="primary"
                   size="lg"
                   className="h-12.5 max-w-none rounded-[23px] shadow-[0_0_16px_rgba(181,244,255,0.5)] disabled:shadow-none"
-                  disabled={!isPasswordVerified}
+                  disabled={!canWithdraw}
                   onClick={handleWithdraw}
                 >
-                  탈퇴하기
+                  {isWithdrawing ? "탈퇴 중..." : "탈퇴하기"}
                 </Button>
               </div>
             </>

--- a/src/pages/admin/WithdrawPage.tsx
+++ b/src/pages/admin/WithdrawPage.tsx
@@ -40,14 +40,14 @@ const NOTICE_ITEMS = [
 const WITHDRAW_REASONS: { code: WithdrawReasonCode; label: string }[] = [
   { code: "ORG_CLOSED", label: "조직(동아리/기관/팀)이 해체되었어요" },
   {
-    code: "NO_LONGER_OPERATING",
+    code: "NO_LONGER_OPERATING_RENTAL",
     label: "물품 대여 업무를 더 이상 운영하지 않아요",
   },
-  { code: "MOVED_SERVICE", label: "다른 서비스로 이전했어요" },
+  { code: "MOVED_TO_OTHER_SERVICE", label: "다른 서비스로 이전했어요" },
   { code: "PRIVACY_CONCERN", label: "개인정보 및 보안이 걱정돼요" },
-  { code: "INCONVENIENT", label: "서비스 사용이 불편했어요" },
-  { code: "LACKING_FEATURES", label: "원하는 기능이 부족했어요" },
-  { code: "INFREQUENT_USE", label: "자주 사용하지 않게 되었어요" },
+  { code: "SERVICE_UNSATISFIED", label: "서비스 사용이 불편했어요" },
+  { code: "MISSING_FEATURE", label: "원하는 기능이 부족했어요" },
+  { code: "LOW_USAGE", label: "자주 사용하지 않게 되었어요" },
   { code: "OTHER", label: "기타" },
 ];
 
@@ -59,6 +59,9 @@ const clearAdminSession = () => {
   localStorage.removeItem("refreshToken");
   localStorage.removeItem("orgId");
 };
+
+const hasAccessToken = () =>
+  typeof window !== "undefined" && Boolean(localStorage.getItem("accessToken"));
 
 const StepIndicator = ({ step }: { step: WithdrawStep }) => {
   const circle = (n: WithdrawStep) => {
@@ -92,7 +95,13 @@ const StepIndicator = ({ step }: { step: WithdrawStep }) => {
 const WithdrawPage = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { data: profile } = useAdminProfile();
+  const [isWithdrawComplete, setIsWithdrawComplete] = useState(false);
+  /** onError 등 비동기 콜백에서 최신 탈퇴 완료 여부를 읽기 위한 ref */
+  const isWithdrawCompleteRef = useRef(false);
+  // 세션이 없거나 탈퇴 완료 후에는 프로필 API를 호출하지 않는다
+  const { data: profile } = useAdminProfile({
+    enabled: hasAccessToken() && !isWithdrawComplete,
+  });
   const { mutate: withdraw, isPending: isWithdrawing } = useWithdraw();
 
   const [step, setStep] = useState<WithdrawStep>(1);
@@ -126,7 +135,19 @@ const WithdrawPage = () => {
     return true;
   }, [agreedToWarning, selectedReasons, otherReason]);
 
-  const canWithdraw = password.trim().length > 0 && !isWithdrawing;
+  const canWithdraw =
+    password.trim().length > 0 && !isWithdrawing && !isWithdrawComplete;
+
+  /** 완료 모달 확인(또는 닫기) 시 세션 정리 후 로그인으로 이동 */
+  const finishWithdraw = () => {
+    clearAdminSession();
+    void queryClient.cancelQueries();
+    setIsCompleteModalOpen(false);
+    navigate("/login", { replace: true });
+    queueMicrotask(() => {
+      queryClient.clear();
+    });
+  };
 
   const toggleReason = (code: WithdrawReasonCode) => {
     setSelectedReasons((prev) => {
@@ -142,6 +163,7 @@ const WithdrawPage = () => {
   };
 
   const handleWithdraw = () => {
+    if (isWithdrawCompleteRef.current) return;
     if (!password.trim()) {
       setIsPasswordMismatchOpen(true);
       return;
@@ -159,14 +181,13 @@ const WithdrawPage = () => {
       },
       {
         onSuccess: () => {
-          clearAdminSession();
-          void queryClient.cancelQueries();
-          queueMicrotask(() => {
-            queryClient.clear();
-          });
+          // 세션은 유지한 채 완료 모달만 띄운다. clear는 확인 클릭 시 수행.
+          isWithdrawCompleteRef.current = true;
+          setIsWithdrawComplete(true);
           setIsCompleteModalOpen(true);
         },
         onError: (error) => {
+          if (isWithdrawCompleteRef.current) return;
           if (axios.isAxiosError(error)) {
             const data = error.response?.data as
               | WithdrawErrorResponse
@@ -192,6 +213,10 @@ const WithdrawPage = () => {
         name="계정관리"
         pageName="탈퇴하기"
         onBackClick={() => {
+          if (isWithdrawComplete) {
+            finishWithdraw();
+            return;
+          }
           if (step === 2) {
             goToStep(1);
             setPassword("");
@@ -321,14 +346,7 @@ const WithdrawPage = () => {
                   disabled={!canGoNext}
                   onClick={() => goToStep(2)}
                 >
-                  <span className="flex items-center gap-1.5">
-                    다음으로
-                    <img
-                      src="/icons/client/left-arrow-white.svg"
-                      alt=""
-                      className="h-3 w-1.5 rotate-180"
-                    />
-                  </span>
+                  <span className="flex items-center gap-1.5">다음으로</span>
                 </Button>
               </div>
             </>
@@ -384,10 +402,8 @@ const WithdrawPage = () => {
       />
       <WithdrawCompleteModal
         isOpen={isCompleteModalOpen}
-        onClose={() => setIsCompleteModalOpen(false)}
-        onConfirm={() => {
-          navigate("/login", { replace: true });
-        }}
+        onClose={finishWithdraw}
+        onConfirm={finishWithdraw}
       />
     </Layout>
   );


### PR DESCRIPTION
## Summary
- 탈퇴 2단계에서 비밀번호 「확인」 버튼·사전 검증 UI 제거
- 「탈퇴하기」 시 `password`를 포함한 `POST /api/admin/v1/account/withdraw` 호출
- 비밀번호 불일치(6007) 시 기존 불일치 모달 표시

## Test plan
- [ ] (요청에 따라 이번 PR에서는 브라우저 테스트 생략)


Made with [Cursor](https://cursor.com)