### PR TITLE
[RTR-264] 결제 수단 관리·등록 페이지 추가

### DIFF
--- a/public/icons/membership/payment-method-placeholder.svg
+++ b/public/icons/membership/payment-method-placeholder.svg
@@ -1,0 +1,4 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0.25" y="0.25" width="13.5" height="13.5" rx="1.75" fill="#F8F9F9" stroke="#CDD6DE" stroke-width="0.5"/>
+  <path d="M9.82843 4.17146L4.17157 9.82832M9.82843 9.82832L4.17157 4.17146" stroke="#CDD6DE" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import AccountTermsPage from "./pages/admin/AccountTermsPage";
 import AccountPrivacyPage from "./pages/admin/AccountPrivacyPage";
 import WithdrawPage from "./pages/admin/WithdrawPage";
 import MembershipPage from "./pages/admin/MembershipPage";
+import PaymentMethodsPage from "./pages/admin/PaymentMethodsPage";
+import PaymentMethodRegisterPage from "./pages/admin/PaymentMethodRegisterPage";
 import ProfileEditPage from "./pages/admin/ProfileEditPage";
 import LandingPage from "./pages/LandingPage";
 import RegisterPage from "./pages/admin/RegisterPage";
@@ -121,6 +123,14 @@ function App() {
           <Route path="/account/privacy" element={<AccountPrivacyPage />} />
           <Route path="/account/withdraw" element={<WithdrawPage />} />
           <Route path="/membership" element={<MembershipPage />} />
+          <Route
+            path="/membership/payment-methods"
+            element={<PaymentMethodsPage />}
+          />
+          <Route
+            path="/membership/payment-methods/register"
+            element={<PaymentMethodRegisterPage />}
+          />
           <Route path="/profile" element={<ProfileEditPage />} />
           <Route path="/item-manage" element={<ItemManagementPage />} />
           <Route path="/item-register" element={<ItemRegisterationPage />} />

--- a/src/components/modals/membership/PaymentMethodDeleteModal.tsx
+++ b/src/components/modals/membership/PaymentMethodDeleteModal.tsx
@@ -1,0 +1,67 @@
+import { Modal } from "../../Modal";
+import Button from "../../Button";
+import type { PaymentMethod } from "../../../types/paymentMethod";
+
+type PaymentMethodDeleteModalProps = {
+  isOpen: boolean;
+  paymentMethod: PaymentMethod | null;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const PaymentMethodDeleteModal = ({
+  isOpen,
+  paymentMethod,
+  onClose,
+  onConfirm,
+}: PaymentMethodDeleteModalProps) => {
+  if (!paymentMethod) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      showTitle={false}
+      showCloseButton={false}
+      modalClassName="!w-[338px] !rounded-[24px] !px-4 !pt-10 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+    >
+      <div className="flex w-full flex-col items-center font-[Pretendard]">
+        <p className="text-center text-20px font-semibold leading-[1.4] text-secondary-1">
+          결제수단을 삭제하시겠어요?
+        </p>
+
+        <div className="mt-4 flex w-full max-w-[274px] flex-col rounded-[7.5px] border border-[#e6eaed] bg-neutral-white px-[18px] py-3">
+          <p className="text-12px font-bold leading-[1.5] text-neutral-gray-1">
+            {paymentMethod.name}
+          </p>
+          {paymentMethod.maskedNumber ? (
+            <p className="text-12px font-normal leading-[1.4] text-neutral-gray-1">
+              {paymentMethod.maskedNumber}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-6 flex h-12 w-full gap-2">
+          <Button
+            variant="outline"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            className="h-12 max-w-none flex-1 rounded-[12px] text-18px shadow-[0_0_4px_rgba(181,244,255,0.5)]"
+            onClick={onConfirm}
+          >
+            삭제하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PaymentMethodDeleteModal;

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -8,6 +8,7 @@ import ConfirmModal from "../../components/modals/ConfirmModal";
 import LogoutConfirmModal from "../../components/modals/admin/account/LogoutConfirmModal";
 import QRCodeDisplay from "../../components/qr/QRCodeDisplay";
 import { useAdminProfile, useLogout } from "../../hooks/queries/useAuthQueries";
+import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
 
 const PRODUCTION_WEB_ORIGIN = "https://www.retrivr.kr";
 const PREVIEW_WEB_ORIGIN = "https://retrivr-web.vercel.app";
@@ -25,6 +26,7 @@ const clearAdminSession = () => {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
   localStorage.removeItem("orgId");
+  resetPaymentMethodsStore();
 };
 
 const AccountPage = () => {

--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -5,6 +5,7 @@ import CommonInput from "../../components/CommonInput";
 import Button from "../../components/Button";
 import { useLogin } from "../../hooks/queries/useAuthQueries";
 import ErrorModal from "../../components/modals/ErrorModal";
+import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -35,6 +36,7 @@ const LoginPage = () => {
       { email, password },
       {
         onSuccess: (data) => {
+          resetPaymentMethodsStore();
           localStorage.setItem("accessToken", data.accessToken);
           // 서버가 refreshToken을 HttpOnly 쿠키로 내려주는 경우 바디에 없을 수 있음
           if (data.refreshToken) {

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";
@@ -40,6 +41,7 @@ const MENU_ITEMS = [
 const COMING_SOON_MESSAGE = "개발 예정입니다.";
 
 const MembershipPage = () => {
+  const navigate = useNavigate();
   const [billingCycle, setBillingCycle] = useState<BillingCycle>("monthly");
   const [couponCode, setCouponCode] = useState("");
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
@@ -52,6 +54,14 @@ const MembershipPage = () => {
 
   const handleComingSoon = () => {
     alert(COMING_SOON_MESSAGE);
+  };
+
+  const handleMenuClick = (menuId: (typeof MENU_ITEMS)[number]["id"]) => {
+    if (menuId === "payment-manage") {
+      navigate("/membership/payment-methods");
+      return;
+    }
+    handleComingSoon();
   };
 
   const handleRegisterCoupon = () => {
@@ -95,7 +105,7 @@ const MembershipPage = () => {
                 <button
                   key={item.id}
                   type="button"
-                  onClick={handleComingSoon}
+                  onClick={() => handleMenuClick(item.id)}
                   className="flex w-full items-center justify-between rounded-[7.5px] border border-[#e6eaed] bg-neutral-white px-[18px] py-3 text-left cursor-pointer"
                 >
                   <div className="flex flex-col">

--- a/src/pages/admin/PaymentMethodRegisterPage.tsx
+++ b/src/pages/admin/PaymentMethodRegisterPage.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Layout } from "../../components/Layout";
+import Header from "../../components/Header";
+import { addPaymentMethod } from "../../store/paymentMethodsStore";
+import {
+  REGISTER_OPTION_LABEL,
+  createRegisteredPaymentMethod,
+  type PaymentMethodRegisterOption,
+} from "../../types/paymentMethod";
+
+const REGISTER_OPTIONS: PaymentMethodRegisterOption[] = [
+  "kakao",
+  "naver",
+  "card",
+];
+
+const PaymentMethodRegisterPage = () => {
+  const navigate = useNavigate();
+  const [selectedOption, setSelectedOption] =
+    useState<PaymentMethodRegisterOption>("card");
+
+  const handleRegister = () => {
+    addPaymentMethod(createRegisteredPaymentMethod(selectedOption));
+    navigate("/membership/payment-methods");
+  };
+
+  return (
+    <Layout>
+      <Header
+        name="결제 수단 관리"
+        pageName="결제 수단 등록"
+        backTo="/membership/payment-methods"
+      />
+
+      <div className="relative flex flex-1 flex-col overflow-y-auto no-scrollbar px-8 pb-28 pt-8 font-[Pretendard]">
+        <section className="flex flex-col gap-1">
+          <h2 className="text-18px font-bold leading-normal text-neutral-gray-1">
+            결제 수단 선택
+          </h2>
+          <p className="text-12px font-normal leading-[1.4] text-neutral-gray-3">
+            등록할 결제수단을 선택해주세요.
+          </p>
+        </section>
+
+        <div className="mt-6 flex flex-col gap-4">
+          {REGISTER_OPTIONS.map((option) => {
+            const isSelected = selectedOption === option;
+
+            return (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setSelectedOption(option)}
+                className={`flex h-[52px] w-full items-center justify-center rounded-[7.5px] border border-[#e6eaed] text-14px font-semibold leading-5 cursor-pointer ${
+                  isSelected
+                    ? "bg-secondary-4 text-primary"
+                    : "bg-neutral-white text-neutral-gray-2"
+                }`}
+              >
+                {REGISTER_OPTION_LABEL[option]}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 px-8 pb-8">
+          <button
+            type="button"
+            onClick={handleRegister}
+            className="pointer-events-auto flex h-[50px] w-full items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-primary cursor-pointer"
+          >
+            등록하기
+          </button>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default PaymentMethodRegisterPage;

--- a/src/pages/admin/PaymentMethodsPage.tsx
+++ b/src/pages/admin/PaymentMethodsPage.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Layout } from "../../components/Layout";
+import Header from "../../components/Header";
+import ConfirmModal from "../../components/modals/ConfirmModal";
+import PaymentMethodDeleteModal from "../../components/modals/membership/PaymentMethodDeleteModal";
+import {
+  removePaymentMethod,
+  setPrimaryPaymentMethod,
+  usePaymentMethodsStore,
+} from "../../store/paymentMethodsStore";
+import type { PaymentMethod } from "../../types/paymentMethod";
+
+const PaymentMethodsPage = () => {
+  const navigate = useNavigate();
+  const { methods, primaryId } = usePaymentMethodsStore();
+  const [deleteTarget, setDeleteTarget] = useState<PaymentMethod | null>(null);
+  const [confirmMessage, setConfirmMessage] = useState<string | null>(null);
+
+  const primaryMethod =
+    methods.find((method) => method.id === primaryId) ?? methods[0] ?? null;
+  const otherMethods = methods.filter(
+    (method) => method.id !== primaryMethod?.id,
+  );
+
+  const handleChangePrimary = (methodId: string) => {
+    if (methodId === primaryId) return;
+    setPrimaryPaymentMethod(methodId);
+    setConfirmMessage("대표 결제 수단 변경이 완료되었어요.");
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    removePaymentMethod(deleteTarget.id);
+    setDeleteTarget(null);
+  };
+
+  return (
+    <Layout>
+      <Header
+        name="Retrivr 프로"
+        pageName="결제 수단 관리"
+        backTo="/membership"
+      />
+
+      <div className="relative flex flex-1 flex-col overflow-y-auto no-scrollbar px-8 pb-28 pt-8 font-[Pretendard]">
+        <section className="flex flex-col gap-2">
+          <h2 className="text-18px font-bold leading-normal text-neutral-gray-1">
+            대표 결제 수단
+          </h2>
+
+          {primaryMethod ? (
+            <div className="flex flex-col gap-0.5 text-secondary-1">
+              <p className="text-12px font-bold leading-[1.5]">
+                {primaryMethod.name}
+              </p>
+              {primaryMethod.maskedNumber ? (
+                <p className="text-16px font-semibold leading-normal">
+                  {primaryMethod.maskedNumber}
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-12px font-normal leading-[1.4] text-neutral-gray-3">
+              등록된 대표 결제 수단이 없어요
+            </p>
+          )}
+
+          <ul className="mt-2 pl-1.5 text-12px font-normal leading-[1.4] text-neutral-gray-3">
+            <li>∙ 다음 결제일에 대표 결제 수단으로 자동 결제됩니다.</li>
+          </ul>
+        </section>
+
+        <section className="mt-6 flex flex-col">
+          <div className="border-t border-[#e6eaed]" />
+          {otherMethods.length === 0 ? (
+            <p className="py-8 text-center text-12px font-normal text-neutral-gray-3">
+              추가 등록된 결제 수단이 없어요
+            </p>
+          ) : (
+            otherMethods.map((method) => (
+              <div key={method.id} className="border-b border-[#e6eaed]">
+                <div className="flex items-center justify-between py-6">
+                  <button
+                    type="button"
+                    onClick={() => setDeleteTarget(method)}
+                    className="flex min-w-0 items-center gap-2 text-left cursor-pointer"
+                    aria-label={`${method.name} 삭제`}
+                  >
+                    <img
+                      src="/icons/membership/payment-method-placeholder.svg"
+                      alt=""
+                      className="size-3.5 shrink-0"
+                      aria-hidden
+                    />
+                    <span className="flex min-w-0 flex-col">
+                      <span className="text-12px font-bold leading-[1.5] text-neutral-gray-1">
+                        {method.name}
+                      </span>
+                      {method.maskedNumber ? (
+                        <span className="text-12px font-normal leading-[1.4] text-neutral-gray-1">
+                          {method.maskedNumber}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => handleChangePrimary(method.id)}
+                    className="flex h-[27px] w-[113px] shrink-0 items-center justify-center rounded-[10px] border border-neutral-gray-2 bg-neutral-white text-12px font-normal leading-[1.4] text-neutral-gray-2 cursor-pointer"
+                  >
+                    대표 수단으로 변경
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </section>
+
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 px-8 pb-8">
+          <button
+            type="button"
+            onClick={() => navigate("/membership/payment-methods/register")}
+            className="pointer-events-auto flex h-[50px] w-full items-center justify-center rounded-[12px] border border-primary bg-neutral-white text-18px font-bold text-primary shadow-[0px_0px_16px_0px_rgba(181,244,255,0.5)] cursor-pointer"
+          >
+            결제수단 등록
+          </button>
+        </div>
+      </div>
+
+      <PaymentMethodDeleteModal
+        isOpen={deleteTarget !== null}
+        paymentMethod={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+      />
+      <ConfirmModal
+        isOpen={confirmMessage !== null}
+        onClose={() => setConfirmMessage(null)}
+        message={confirmMessage ?? ""}
+        confirmText="확인"
+      />
+    </Layout>
+  );
+};
+
+export default PaymentMethodsPage;

--- a/src/pages/admin/WithdrawPage.tsx
+++ b/src/pages/admin/WithdrawPage.tsx
@@ -18,6 +18,7 @@ import type {
   WithdrawReasonCode,
 } from "../../api/auth/auth.type";
 import { WITHDRAW_ERROR_CODE } from "../../api/auth/auth.type";
+import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
 
 const NOTICE_ITEMS = [
   {
@@ -58,6 +59,7 @@ const clearAdminSession = () => {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
   localStorage.removeItem("orgId");
+  resetPaymentMethodsStore();
 };
 
 const hasAccessToken = () =>

--- a/src/store/paymentMethodsStore.ts
+++ b/src/store/paymentMethodsStore.ts
@@ -1,0 +1,66 @@
+import { useSyncExternalStore } from "react";
+import {
+  INITIAL_PAYMENT_METHODS,
+  INITIAL_PRIMARY_PAYMENT_METHOD_ID,
+  type PaymentMethod,
+} from "../types/paymentMethod";
+
+type PaymentMethodsStoreSnapshot = {
+  methods: PaymentMethod[];
+  primaryId: string;
+};
+
+let methods: PaymentMethod[] = INITIAL_PAYMENT_METHODS;
+let primaryId = INITIAL_PRIMARY_PAYMENT_METHOD_ID;
+let snapshot: PaymentMethodsStoreSnapshot = { methods, primaryId };
+const listeners = new Set<() => void>();
+
+const emitChange = () => {
+  snapshot = { methods, primaryId };
+  listeners.forEach((listener) => listener());
+};
+
+const getSnapshot = () => snapshot;
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const setPrimaryPaymentMethod = (methodId: string) => {
+  if (!methods.some((method) => method.id === methodId)) return;
+  if (primaryId === methodId) return;
+  primaryId = methodId;
+  emitChange();
+};
+
+export const addPaymentMethod = (method: PaymentMethod) => {
+  if (methods.some((item) => item.id === method.id)) return;
+  methods = [...methods, method];
+  if (!primaryId) {
+    primaryId = method.id;
+  }
+  emitChange();
+};
+
+export const removePaymentMethod = (methodId: string) => {
+  const nextMethods = methods.filter((method) => method.id !== methodId);
+  if (nextMethods.length === methods.length) return;
+
+  methods = nextMethods;
+  if (primaryId === methodId) {
+    primaryId = nextMethods[0]?.id ?? "";
+  }
+  emitChange();
+};
+
+export const resetPaymentMethodsStore = () => {
+  methods = [...INITIAL_PAYMENT_METHODS];
+  primaryId = INITIAL_PRIMARY_PAYMENT_METHOD_ID;
+  emitChange();
+};
+
+export const usePaymentMethodsStore = () =>
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/src/types/paymentMethod.ts
+++ b/src/types/paymentMethod.ts
@@ -1,0 +1,79 @@
+export type PaymentMethodKind = "card" | "bank" | "kakao" | "naver";
+
+export type PaymentMethod = {
+  id: string;
+  name: string;
+  maskedNumber?: string;
+  kind: PaymentMethodKind;
+};
+
+export type PaymentMethodRegisterOption = "kakao" | "naver" | "card";
+
+export const INITIAL_PAYMENT_METHODS: PaymentMethod[] = [
+  {
+    id: "shinhan-card",
+    name: "신한카드",
+    maskedNumber: "348313*******123",
+    kind: "card",
+  },
+  {
+    id: "woori-bank",
+    name: "우리은행",
+    maskedNumber: "**********26123",
+    kind: "bank",
+  },
+  {
+    id: "kb-bank",
+    name: "국민은행",
+    maskedNumber: "**********26123",
+    kind: "bank",
+  },
+  {
+    id: "kakao-pay",
+    name: "카카오페이",
+    kind: "kakao",
+  },
+  {
+    id: "naver-pay",
+    name: "네이버페이",
+    kind: "naver",
+  },
+];
+
+export const INITIAL_PRIMARY_PAYMENT_METHOD_ID = "shinhan-card";
+
+export const REGISTER_OPTION_LABEL: Record<PaymentMethodRegisterOption, string> =
+  {
+    kakao: "카카오페이",
+    naver: "네이버페이",
+    card: "카드 등록",
+  };
+
+export const createRegisteredPaymentMethod = (
+  option: PaymentMethodRegisterOption,
+): PaymentMethod => {
+  const id = `${option}-${Date.now()}`;
+
+  if (option === "card") {
+    return {
+      id,
+      name: "신한카드",
+      maskedNumber: "348313*******123",
+      kind: "card",
+    };
+  }
+
+  if (option === "kakao") {
+    return {
+      id,
+      name: "카카오페이",
+      kind: "kakao",
+    };
+  }
+
+  return {
+    id,
+    name: "네이버페이",
+    kind: "naver",
+  };
+};


### PR DESCRIPTION
## Summary
- 결제 수단 관리/등록 페이지와 삭제 확인 모달 추가
- 멤버십 → 결제 수단 관리 연결
- 대표 결제 수단 변경 완료는 기존 ConfirmModal 메시지 사용
- 목업 스토어로 라우트 간 상태 유지, 로그인·로그아웃·탈퇴 시 초기화

## Test plan
- [ ] 멤버십에서 결제 수단 관리 진입
- [ ] 대표 수단 변경 시 완료 모달 문구 확인
- [ ] 비대표 수단 탭 → 삭제 모달 → 삭제
- [ ] 결제수단 등록 후 목록 반영
- [ ] 로그인/로그아웃 후 목업 목록 초기화


Made with [Cursor](https://cursor.com)