### PR TITLE
[RTR-264] 이용권 목록 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import WithdrawPage from "./pages/admin/WithdrawPage";
 import MembershipPage from "./pages/admin/MembershipPage";
 import PaymentMethodsPage from "./pages/admin/PaymentMethodsPage";
 import PaymentMethodRegisterPage from "./pages/admin/PaymentMethodRegisterPage";
+import VoucherListPage from "./pages/admin/VoucherListPage";
 import ProfileEditPage from "./pages/admin/ProfileEditPage";
 import LandingPage from "./pages/LandingPage";
 import RegisterPage from "./pages/admin/RegisterPage";
@@ -131,6 +132,7 @@ function App() {
             path="/membership/payment-methods/register"
             element={<PaymentMethodRegisterPage />}
           />
+          <Route path="/membership/vouchers" element={<VoucherListPage />} />
           <Route path="/profile" element={<ProfileEditPage />} />
           <Route path="/item-manage" element={<ItemManagementPage />} />
           <Route path="/item-register" element={<ItemRegisterationPage />} />

--- a/src/components/membership/CouponVoucherPanel.tsx
+++ b/src/components/membership/CouponVoucherPanel.tsx
@@ -1,0 +1,26 @@
+import {
+  COUPON_USAGE_GUIDE,
+  COUPON_VOUCHERS,
+} from "../../types/voucherList";
+import MembershipCouponCard from "./MembershipCouponCard";
+import UsageGuideCard from "./UsageGuideCard";
+
+const CouponVoucherPanel = () => (
+  <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-2.5">
+      {COUPON_VOUCHERS.map((voucher) => (
+        <MembershipCouponCard
+          key={voucher.id}
+          title={voucher.title}
+          eventName={voucher.eventName}
+          status={voucher.status}
+          footerText={voucher.footerText}
+          compact
+        />
+      ))}
+    </div>
+    <UsageGuideCard items={COUPON_USAGE_GUIDE} />
+  </div>
+);
+
+export default CouponVoucherPanel;

--- a/src/components/membership/HistoryDateChipGroup.tsx
+++ b/src/components/membership/HistoryDateChipGroup.tsx
@@ -1,0 +1,36 @@
+import type { WheelDate } from "./HistoryDateWheel";
+
+type HistoryDateChipGroupProps = {
+  value: WheelDate;
+  isActive: boolean;
+  onClick: () => void;
+};
+
+const HistoryDateChipGroup = ({
+  value,
+  isActive,
+  onClick,
+}: HistoryDateChipGroupProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`flex items-center gap-1 rounded-md p-0.5 cursor-pointer ${
+      isActive ? "ring-1 ring-primary/40" : ""
+    }`}
+  >
+    {[
+      String(value.year),
+      String(value.month).padStart(2, "0"),
+      String(value.day).padStart(2, "0"),
+    ].map((part, index) => (
+      <span
+        key={`${part}-${index}`}
+        className="inline-flex h-[19px] min-w-[19px] items-center justify-center rounded-[4px] bg-neutral-white px-1 text-10px font-semibold leading-[1.3] text-neutral-gray-1"
+      >
+        {part}
+      </span>
+    ))}
+  </button>
+);
+
+export default HistoryDateChipGroup;

--- a/src/components/membership/HistoryDateWheel.tsx
+++ b/src/components/membership/HistoryDateWheel.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useRef } from "react";
+import { HISTORY_YEAR_RANGE } from "../../utils/voucherHistory";
+
+const WHEEL_ITEM_HEIGHT = 29;
+
+type DateWheelColumnProps = {
+  values: number[];
+  selectedValue: number;
+  unit: string;
+  onChange: (value: number) => void;
+  formatter?: (value: number) => string;
+};
+
+const DateWheelColumn = ({
+  values,
+  selectedValue,
+  unit,
+  onChange,
+  formatter = (value) => String(value).padStart(2, "0"),
+}: DateWheelColumnProps) => {
+  const wheelRef = useRef<HTMLDivElement | null>(null);
+  const settleTimerRef = useRef<number | null>(null);
+  const wheelRows = useMemo(
+    () => [null, ...values, null] as Array<number | null>,
+    [values],
+  );
+
+  const clearSettleTimer = () => {
+    if (settleTimerRef.current) {
+      window.clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
+    }
+  };
+
+  const scrollToValue = (value: number, behavior: ScrollBehavior = "auto") => {
+    const container = wheelRef.current;
+    if (!container) return;
+    const index = values.indexOf(value);
+    if (index < 0) return;
+    container.scrollTo({
+      top: index * WHEEL_ITEM_HEIGHT,
+      behavior,
+    });
+  };
+
+  useEffect(() => {
+    clearSettleTimer();
+    scrollToValue(selectedValue, "auto");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedValue, values]);
+
+  useEffect(() => {
+    return () => {
+      clearSettleTimer();
+    };
+  }, []);
+
+  const handleScroll = () => {
+    const container = wheelRef.current;
+    if (!container) return;
+
+    const nearestIndex = Math.round(container.scrollTop / WHEEL_ITEM_HEIGHT);
+    const clampedIndex = Math.max(0, Math.min(values.length - 1, nearestIndex));
+    const nextValue = values[clampedIndex];
+    if (nextValue !== selectedValue) {
+      onChange(nextValue);
+    }
+
+    clearSettleTimer();
+    settleTimerRef.current = window.setTimeout(() => {
+      scrollToValue(nextValue, "smooth");
+    }, 80);
+  };
+
+  return (
+    <div className="relative min-w-[56px]">
+      <div
+        ref={wheelRef}
+        onScroll={handleScroll}
+        className="h-[87px] overflow-y-auto no-scrollbar snap-y snap-mandatory"
+      >
+        {wheelRows.map((value, index) => (
+          <div
+            key={`${value ?? "spacer"}-${index}`}
+            className="flex h-[29px] items-center justify-center snap-start"
+          >
+            {value === null ? null : (
+              <button
+                type="button"
+                onClick={() => {
+                  onChange(value);
+                  scrollToValue(value, "smooth");
+                }}
+                className={`z-10 whitespace-nowrap text-12px leading-[1.4] cursor-pointer ${
+                  value === selectedValue
+                    ? "font-semibold text-neutral-gray-1"
+                    : "font-normal text-neutral-gray-4"
+                }`}
+              >
+                {formatter(value)}
+                {unit}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export type WheelDate = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+type HistoryDateWheelProps = {
+  value: WheelDate;
+  onChange: (next: WheelDate) => void;
+};
+
+const getDaysInMonth = (year: number, month: number) =>
+  new Date(year, month, 0).getDate();
+
+const HistoryDateWheel = ({ value, onChange }: HistoryDateWheelProps) => {
+  const years = useMemo(() => {
+    const minYear = Math.min(HISTORY_YEAR_RANGE.min, value.year);
+    const maxYear = Math.max(HISTORY_YEAR_RANGE.max, value.year);
+    return Array.from(
+      { length: maxYear - minYear + 1 },
+      (_, index) => minYear + index,
+    );
+  }, [value.year]);
+
+  const months = useMemo(
+    () => Array.from({ length: 12 }, (_, index) => index + 1),
+    [],
+  );
+  const days = useMemo(
+    () =>
+      Array.from(
+        { length: getDaysInMonth(value.year, value.month) },
+        (_, index) => index + 1,
+      ),
+    [value.year, value.month],
+  );
+
+  const update = (partial: Partial<WheelDate>) => {
+    const next = { ...value, ...partial };
+    const maxDay = getDaysInMonth(next.year, next.month);
+    if (next.day > maxDay) next.day = maxDay;
+    onChange(next);
+  };
+
+  return (
+    <div className="mt-4 flex items-center justify-center gap-5">
+      <DateWheelColumn
+        values={years}
+        selectedValue={value.year}
+        unit="년"
+        formatter={(year) => String(year)}
+        onChange={(year) => update({ year })}
+      />
+      <DateWheelColumn
+        values={months}
+        selectedValue={value.month}
+        unit="월"
+        onChange={(month) => update({ month })}
+      />
+      <DateWheelColumn
+        values={days}
+        selectedValue={value.day}
+        unit="일"
+        onChange={(day) => update({ day })}
+      />
+    </div>
+  );
+};
+
+export default HistoryDateWheel;

--- a/src/components/membership/HistoryPeriodFilter.tsx
+++ b/src/components/membership/HistoryPeriodFilter.tsx
@@ -1,0 +1,118 @@
+import {
+  HISTORY_PERIOD_LABEL,
+  type HistoryPeriodOption,
+} from "../../types/voucherList";
+import HistoryDateChipGroup from "./HistoryDateChipGroup";
+import HistoryDateWheel, { type WheelDate } from "./HistoryDateWheel";
+
+const PERIOD_OPTIONS: HistoryPeriodOption[] = [
+  "all",
+  "1m",
+  "6m",
+  "1y",
+  "custom",
+];
+
+type HistoryPeriodFilterProps = {
+  isOpen: boolean;
+  period: HistoryPeriodOption;
+  editingSide: "start" | "end";
+  customStart: WheelDate;
+  customEnd: WheelDate;
+  onToggleOpen: () => void;
+  onSelectPeriod: (period: HistoryPeriodOption) => void;
+  onChangeEditingSide: (side: "start" | "end") => void;
+  onChangeCustomStart: (value: WheelDate) => void;
+  onChangeCustomEnd: (value: WheelDate) => void;
+};
+
+const HistoryPeriodFilter = ({
+  isOpen,
+  period,
+  editingSide,
+  customStart,
+  customEnd,
+  onToggleOpen,
+  onSelectPeriod,
+  onChangeEditingSide,
+  onChangeCustomStart,
+  onChangeCustomEnd,
+}: HistoryPeriodFilterProps) => (
+  <div className="flex flex-col gap-2">
+    <button
+      type="button"
+      onClick={onToggleOpen}
+      className="flex w-fit items-center gap-2 rounded-md bg-secondary-4 px-2.5 py-1.5 cursor-pointer"
+    >
+      <span className="text-12px font-semibold leading-[1.4] text-neutral-gray-1">
+        {HISTORY_PERIOD_LABEL[period]}
+      </span>
+      <img
+        src="/icons/right-arrow2.svg"
+        alt=""
+        className={`h-[8.4px] w-[4.2px] transition-transform ${
+          isOpen ? "-rotate-90" : "rotate-90"
+        }`}
+        aria-hidden
+      />
+    </button>
+
+    {isOpen ? (
+      <div className="flex items-center gap-1 overflow-x-auto no-scrollbar rounded-[7.5px] bg-secondary-4 px-2.5 py-2.5">
+        {PERIOD_OPTIONS.map((option) => {
+          const isSelected = period === option;
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onSelectPeriod(option)}
+              className="flex shrink-0 items-center gap-1 px-1.5 py-0.5 cursor-pointer"
+            >
+              <span
+                className={`size-1 shrink-0 rounded-full ${
+                  isSelected ? "bg-primary" : "bg-neutral-gray-4"
+                }`}
+                aria-hidden
+              />
+              <span
+                className={`text-12px leading-[1.4] whitespace-nowrap ${
+                  isSelected
+                    ? "font-semibold text-neutral-gray-1"
+                    : "font-medium text-neutral-gray-3"
+                }`}
+              >
+                {HISTORY_PERIOD_LABEL[option]}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    ) : null}
+
+    {isOpen && period === "custom" ? (
+      <div className="rounded-[7.5px] bg-secondary-4 px-4 py-[18px]">
+        <div className="flex items-center justify-center gap-2">
+          <HistoryDateChipGroup
+            value={customStart}
+            isActive={editingSide === "start"}
+            onClick={() => onChangeEditingSide("start")}
+          />
+          <span className="text-12px font-medium text-neutral-gray-3">~</span>
+          <HistoryDateChipGroup
+            value={customEnd}
+            isActive={editingSide === "end"}
+            onClick={() => onChangeEditingSide("end")}
+          />
+        </div>
+        <HistoryDateWheel
+          value={editingSide === "start" ? customStart : customEnd}
+          onChange={
+            editingSide === "start" ? onChangeCustomStart : onChangeCustomEnd
+          }
+        />
+      </div>
+    ) : null}
+  </div>
+);
+
+export default HistoryPeriodFilter;

--- a/src/components/membership/SubscriptionVoucherPanel.tsx
+++ b/src/components/membership/SubscriptionVoucherPanel.tsx
@@ -1,0 +1,63 @@
+import {
+  SUBSCRIPTION_USAGE_GUIDE,
+  SUBSCRIPTION_VOUCHER,
+} from "../../types/voucherList";
+import UsageGuideCard from "./UsageGuideCard";
+
+type SubscriptionVoucherPanelProps = {
+  onCancelSubscription?: () => void;
+};
+
+const SubscriptionVoucherPanel = ({
+  onCancelSubscription,
+}: SubscriptionVoucherPanelProps) => (
+  <div className="flex flex-col gap-4">
+    <article className="flex flex-col rounded-2xl bg-neutral-white px-[26px] py-6 shadow-[0px_0px_16px_-6px_rgba(0,0,0,0.2)]">
+      <div className="flex items-center gap-[5px]">
+        <h2 className="text-16px font-bold leading-normal text-neutral-gray-1">
+          {SUBSCRIPTION_VOUCHER.title}
+        </h2>
+        <span className="inline-flex h-[18px] items-center justify-center rounded-[9px] border-[0.5px] border-secondary-2 bg-neutral-gray-5 px-[7px]">
+          <span className="text-10px font-bold leading-[1.3] text-secondary-2">
+            {SUBSCRIPTION_VOUCHER.statusLabel}
+          </span>
+        </span>
+      </div>
+
+      <p className="mt-2 whitespace-pre-line text-12px font-normal leading-[1.4] text-neutral-gray-3">
+        {SUBSCRIPTION_VOUCHER.description}
+      </p>
+
+      <div className="mt-4 flex h-[61px] w-full items-center justify-between rounded-[7.5px] border border-primary bg-secondary-4 pl-5 pr-[18px]">
+        <span className="text-18px font-bold leading-normal text-primary">
+          {SUBSCRIPTION_VOUCHER.durationLabel}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-12px font-normal leading-[1.4] text-neutral-gray-4 line-through">
+            {SUBSCRIPTION_VOUCHER.originalPrice}
+          </span>
+          <p className="text-14px font-bold leading-5 text-primary">
+            <span className="font-semibold text-neutral-gray-1">
+              {SUBSCRIPTION_VOUCHER.priceAmount}
+            </span>
+            <span className="font-medium text-neutral-gray-3">
+              {SUBSCRIPTION_VOUCHER.priceUnit}
+            </span>
+          </p>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onCancelSubscription}
+        className="mt-4 self-end text-12px font-medium leading-[1.5] text-neutral-gray-3 underline cursor-pointer"
+      >
+        구독 해지
+      </button>
+    </article>
+
+    <UsageGuideCard items={SUBSCRIPTION_USAGE_GUIDE} />
+  </div>
+);
+
+export default SubscriptionVoucherPanel;

--- a/src/components/membership/UsageGuideCard.tsx
+++ b/src/components/membership/UsageGuideCard.tsx
@@ -1,0 +1,28 @@
+type UsageGuideCardProps = {
+  items: string[];
+};
+
+const UsageGuideCard = ({ items }: UsageGuideCardProps) => (
+  <section className="rounded-[12px] border border-[#e6eaed] bg-neutral-white px-3.5 py-3.5">
+    <h3 className="text-12px font-bold leading-[1.5] text-neutral-gray-3">
+      이용권 사용 안내
+    </h3>
+    <ul className="mt-1 flex flex-col">
+      {items.map((item) => (
+        <li key={item} className="flex items-start gap-0">
+          <span
+            className="mt-[7px] flex size-[17px] shrink-0 items-center justify-center"
+            aria-hidden
+          >
+            <span className="size-0.5 rounded-full bg-neutral-gray-3" />
+          </span>
+          <p className="text-12px font-normal leading-[1.4] text-neutral-gray-3">
+            {item}
+          </p>
+        </li>
+      ))}
+    </ul>
+  </section>
+);
+
+export default UsageGuideCard;

--- a/src/components/membership/UsageHistoryItemCard.tsx
+++ b/src/components/membership/UsageHistoryItemCard.tsx
@@ -1,0 +1,29 @@
+import type { UsageHistoryItem } from "../../types/voucherList";
+
+type UsageHistoryItemCardProps = {
+  item: UsageHistoryItem;
+};
+
+const UsageHistoryItemCard = ({ item }: UsageHistoryItemCardProps) => (
+  <article className="flex items-center justify-between rounded-[7.5px] border border-[#e6eaed] bg-neutral-white px-[18px] py-4">
+    <div className="flex flex-col">
+      <p className="text-12px font-bold leading-[1.5] text-neutral-gray-2">
+        {item.title}
+      </p>
+      <p className="text-10px font-normal leading-[1.3] text-neutral-gray-3">
+        {item.datetimeLabel}
+      </p>
+    </div>
+    {item.kind === "payment" ? (
+      <p className="text-14px font-semibold leading-5 text-neutral-gray-1">
+        {item.amountLabel}
+      </p>
+    ) : (
+      <p className="text-10px font-semibold leading-normal text-secondary-2">
+        쿠폰 사용
+      </p>
+    )}
+  </article>
+);
+
+export default UsageHistoryItemCard;

--- a/src/components/membership/UsageHistoryPanel.tsx
+++ b/src/components/membership/UsageHistoryPanel.tsx
@@ -1,0 +1,77 @@
+import { useMemo, useState } from "react";
+import {
+  USAGE_HISTORY_ITEMS,
+  type HistoryPeriodOption,
+} from "../../types/voucherList";
+import {
+  HISTORY_DATE_BOUNDS,
+  filterUsageHistory,
+} from "../../utils/voucherHistory";
+import type { WheelDate } from "./HistoryDateWheel";
+import HistoryPeriodFilter from "./HistoryPeriodFilter";
+import UsageHistoryItemCard from "./UsageHistoryItemCard";
+
+const UsageHistoryPanel = () => {
+  const [isPeriodOpen, setIsPeriodOpen] = useState(false);
+  const [period, setPeriod] = useState<HistoryPeriodOption>("all");
+  const [editingSide, setEditingSide] = useState<"start" | "end">("start");
+  const [customStart, setCustomStart] = useState<WheelDate>(
+    HISTORY_DATE_BOUNDS.start,
+  );
+  const [customEnd, setCustomEnd] = useState<WheelDate>(
+    HISTORY_DATE_BOUNDS.end,
+  );
+
+  const filteredHistory = useMemo(
+    () =>
+      filterUsageHistory(
+        USAGE_HISTORY_ITEMS,
+        period,
+        customStart,
+        customEnd,
+      ),
+    [period, customStart, customEnd],
+  );
+
+  const handleSelectPeriod = (next: HistoryPeriodOption) => {
+    if (next === "custom") {
+      setCustomStart(HISTORY_DATE_BOUNDS.start);
+      setCustomEnd(HISTORY_DATE_BOUNDS.end);
+      setPeriod(next);
+      return;
+    }
+    setPeriod(next);
+    setIsPeriodOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <HistoryPeriodFilter
+        isOpen={isPeriodOpen}
+        period={period}
+        editingSide={editingSide}
+        customStart={customStart}
+        customEnd={customEnd}
+        onToggleOpen={() => setIsPeriodOpen((open) => !open)}
+        onSelectPeriod={handleSelectPeriod}
+        onChangeEditingSide={setEditingSide}
+        onChangeCustomStart={setCustomStart}
+        onChangeCustomEnd={setCustomEnd}
+      />
+
+      <div className="mt-2 flex flex-col gap-2">
+        {filteredHistory.length === 0 ? (
+          <p className="py-10 text-center text-12px text-neutral-gray-3">
+            선택한 기간의 이용 내역이 없어요
+          </p>
+        ) : (
+          filteredHistory.map((item) => (
+            <UsageHistoryItemCard key={item.id} item={item} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UsageHistoryPanel;

--- a/src/components/membership/VoucherListTabs.tsx
+++ b/src/components/membership/VoucherListTabs.tsx
@@ -1,0 +1,49 @@
+import type { VoucherListTab } from "../../types/voucherList";
+
+const TABS: { id: VoucherListTab; label: string }[] = [
+  { id: "subscription", label: "구독 이용권" },
+  { id: "coupon", label: "쿠폰 이용권" },
+  { id: "history", label: "이용 내역" },
+];
+
+type VoucherListTabsProps = {
+  activeTab: VoucherListTab;
+  onChange: (tab: VoucherListTab) => void;
+};
+
+const VoucherListTabs = ({ activeTab, onChange }: VoucherListTabsProps) => (
+  <div className="relative mt-5">
+    <div
+      className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-neutral-gray-5"
+      aria-hidden
+    />
+    <div className="relative z-10 flex w-full items-end justify-between px-5">
+      {TABS.map((tab) => {
+        const isActive = activeTab === tab.id;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onChange(tab.id)}
+            className="relative flex w-20 flex-col items-center gap-2.5 cursor-pointer"
+          >
+            <span
+              className={`text-14px font-semibold leading-5 ${
+                isActive ? "text-primary" : "text-neutral-gray-4"
+              }`}
+            >
+              {tab.label}
+            </span>
+            <span
+              className={`h-[3px] w-full rounded-[1.5px] ${
+                isActive ? "bg-primary" : "bg-transparent"
+              }`}
+            />
+          </button>
+        );
+      })}
+    </div>
+  </div>
+);
+
+export default VoucherListTabs;

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -61,6 +61,10 @@ const MembershipPage = () => {
       navigate("/membership/payment-methods");
       return;
     }
+    if (menuId === "voucher-manage") {
+      navigate("/membership/vouchers");
+      return;
+    }
     handleComingSoon();
   };
 
@@ -211,7 +215,7 @@ const MembershipPage = () => {
               <p className="text-12px font-normal leading-[1.4] text-neutral-gray-3">
                 이벤트나 제휴를 통해 받은 쿠폰번호를 등록하면
                 <br />
-                이용권이 지급돼요
+                이용권이 지급돼요.
               </p>
             </div>
 

--- a/src/pages/admin/VoucherListPage.tsx
+++ b/src/pages/admin/VoucherListPage.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { Layout } from "../../components/Layout";
+import Header from "../../components/Header";
+import CouponVoucherPanel from "../../components/membership/CouponVoucherPanel";
+import SubscriptionVoucherPanel from "../../components/membership/SubscriptionVoucherPanel";
+import UsageHistoryPanel from "../../components/membership/UsageHistoryPanel";
+import VoucherListTabs from "../../components/membership/VoucherListTabs";
+import type { VoucherListTab } from "../../types/voucherList";
+
+const VoucherListPage = () => {
+  const [activeTab, setActiveTab] = useState<VoucherListTab>("subscription");
+
+  return (
+    <Layout>
+      <Header name="Retrivr 프로" pageName="이용권 목록" backTo="/membership" />
+
+      <div className="flex flex-1 flex-col overflow-y-auto no-scrollbar px-8 pb-10 font-[Pretendard]">
+        <VoucherListTabs activeTab={activeTab} onChange={setActiveTab} />
+
+        <div className="mt-8 flex flex-col gap-4">
+          {activeTab === "subscription" ? (
+            <SubscriptionVoucherPanel
+              onCancelSubscription={() => alert("개발 예정입니다.")}
+            />
+          ) : null}
+          {activeTab === "coupon" ? <CouponVoucherPanel /> : null}
+          {activeTab === "history" ? <UsageHistoryPanel /> : null}
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default VoucherListPage;

--- a/src/types/voucherList.ts
+++ b/src/types/voucherList.ts
@@ -1,0 +1,93 @@
+export type VoucherListTab = "subscription" | "coupon" | "history";
+
+export type HistoryPeriodOption = "all" | "1m" | "6m" | "1y" | "custom";
+
+export type UsageHistoryItem = {
+  id: string;
+  title: string;
+  datetimeLabel: string;
+  occurredAt: string; // ISO date YYYY-MM-DD
+  kind: "payment" | "coupon";
+  amountLabel?: string;
+};
+
+export const HISTORY_PERIOD_LABEL: Record<HistoryPeriodOption, string> = {
+  all: "전체",
+  "1m": "1개월",
+  "6m": "6개월",
+  "1y": "1년",
+  custom: "직접입력",
+};
+
+export const SUBSCRIPTION_VOUCHER = {
+  title: "연간 이용권",
+  statusLabel: "일시중지",
+  description:
+    "등록된 쿠폰 이용권을 모두 사용하면\n26.09.01부터 자동 결제가 다시 진행돼요.",
+  durationLabel: "12개월",
+  originalPrice: "58,800",
+  priceAmount: "46,900₩",
+  priceUnit: "/연",
+};
+
+export const COUPON_VOUCHERS = [
+  {
+    id: "coupon-active",
+    title: "2개월 이용권 쿠폰",
+    eventName: "Retrivr 출시 이벤트",
+    status: "active" as const,
+    footerText: "사용 기간: 26. 05. 01 ~ 26. 06. 30",
+  },
+  {
+    id: "coupon-pending",
+    title: "2개월 이용권 쿠폰",
+    eventName: "Retrivr 출시 이벤트",
+    status: "pending" as const,
+    footerText: "26. 07. 01 활성화 예정",
+  },
+];
+
+export const SUBSCRIPTION_USAGE_GUIDE = [
+  "쿠폰 코드를 등록하면 쿠폰 이용권을 사용할 수 있습니다.",
+  "쿠폰 이용권은 등록 즉시 활성화됩니다.",
+  "현재 구독 이용권을 사용 중인 경우에는 다음 결제일부터 쿠폰 이용권이 우선 적용됩니다.",
+];
+
+export const COUPON_USAGE_GUIDE = [
+  "쿠폰 코드를 등록하여 쿠폰 이용권을 사용할 수 있습니다.",
+  "쿠폰 이용권은 등록 즉시 활성화됩니다.",
+  "현재 사용 중인 구독 이용권이 있는 경우, 다음 결제 주기(익월)부터 쿠폰 이용권이 우선 적용됩니다.",
+];
+
+export const USAGE_HISTORY_ITEMS: UsageHistoryItem[] = [
+  {
+    id: "history-1",
+    title: "월간 이용권 결제",
+    datetimeLabel: "2026. 07. 04.(금) 14:32",
+    occurredAt: "2026-07-04",
+    kind: "payment",
+    amountLabel: "4,900₩",
+  },
+  {
+    id: "history-2",
+    title: "2달 이용권 쿠폰 사용",
+    datetimeLabel: "2026. 05. 01.(금) 10:00",
+    occurredAt: "2026-05-01",
+    kind: "coupon",
+  },
+  {
+    id: "history-3",
+    title: "연간 이용권 결제",
+    datetimeLabel: "2026. 03. 31.(월) 11:20",
+    occurredAt: "2026-03-31",
+    kind: "payment",
+    amountLabel: "46,900₩",
+  },
+  {
+    id: "history-4",
+    title: "1달 이용권 쿠폰 사용",
+    datetimeLabel: "2026. 03. 15.(토) 09:20",
+    occurredAt: "2026-03-15",
+    kind: "coupon",
+  },
+];

--- a/src/utils/voucherHistory.ts
+++ b/src/utils/voucherHistory.ts
@@ -1,0 +1,86 @@
+import type { WheelDate } from "../components/membership/HistoryDateWheel";
+import {
+  USAGE_HISTORY_ITEMS,
+  type HistoryPeriodOption,
+  type UsageHistoryItem,
+} from "../types/voucherList";
+
+export const parseLocalDate = (isoDate: string) => {
+  const [year, month, day] = isoDate.split("-").map(Number);
+  return new Date(year, month - 1, day);
+};
+
+export const startOfDay = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+export const endOfDay = (date: Date) =>
+  new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    23,
+    59,
+    59,
+    999,
+  );
+
+export const toWheelDate = (date: Date): WheelDate => ({
+  year: date.getFullYear(),
+  month: date.getMonth() + 1,
+  day: date.getDate(),
+});
+
+export const fromWheelDate = (value: WheelDate) =>
+  new Date(value.year, value.month - 1, value.day);
+
+export const shiftMonths = (base: Date, months: number) => {
+  const next = new Date(base);
+  next.setMonth(next.getMonth() - months);
+  return startOfDay(next);
+};
+
+export const HISTORY_DATE_BOUNDS = (() => {
+  if (USAGE_HISTORY_ITEMS.length === 0) {
+    const today = toWheelDate(new Date());
+    return { start: today, end: today };
+  }
+
+  const timestamps = USAGE_HISTORY_ITEMS.map((item) =>
+    parseLocalDate(item.occurredAt).getTime(),
+  );
+  return {
+    start: toWheelDate(new Date(Math.min(...timestamps))),
+    end: toWheelDate(new Date(Math.max(...timestamps))),
+  };
+})();
+
+const currentYear = new Date().getFullYear();
+
+export const HISTORY_YEAR_RANGE = {
+  min: Math.min(HISTORY_DATE_BOUNDS.start.year, currentYear - 5),
+  max: Math.max(HISTORY_DATE_BOUNDS.end.year, currentYear + 5),
+};
+
+export const filterUsageHistory = (
+  items: UsageHistoryItem[],
+  period: HistoryPeriodOption,
+  customStart: WheelDate,
+  customEnd: WheelDate,
+) => {
+  if (period === "all") return items;
+
+  if (period === "custom") {
+    const start = fromWheelDate(customStart);
+    const end = fromWheelDate(customEnd);
+    const from = startOfDay(start <= end ? start : end);
+    const to = endOfDay(start <= end ? end : start);
+    return items.filter((item) => {
+      const date = parseLocalDate(item.occurredAt);
+      return date >= from && date <= to;
+    });
+  }
+
+  const months = period === "1m" ? 1 : period === "6m" ? 6 : 12;
+  const from = shiftMonths(new Date(), months);
+  return items.filter((item) => parseLocalDate(item.occurredAt) >= from);
+};


### PR DESCRIPTION
## Summary
- 이용권 목록 페이지(구독/쿠폰/이용 내역) 추가 및 멤버십 연결
- 탭·패널·기간 필터·날짜 휠을 membership 컴포넌트로 분리
- 날짜 휠 settle 타이머, 빈 내역 bounds, 연도 범위 이슈 수정

## Test plan
- [ ] 멤버십 → 이용권 관리 진입
- [ ] 탭 전환 시 하단 primary 인디케이터 확인
- [ ] 이용 내역 기간 필터·직접입력 날짜 휠 동작
- [ ] 시작/종료 칩 전환 후 날짜가 이전 값으로 되돌아가지 않는지 확인


Made with [Cursor](https://cursor.com)