### PR TITLE
[RTR-264] main 머지 전 Bugbot 고위험 이슈 수정

### DIFF
--- a/src/components/membership/HistoryDateWheel.tsx
+++ b/src/components/membership/HistoryDateWheel.tsx
@@ -20,10 +20,6 @@ const DateWheelColumn = ({
 }: DateWheelColumnProps) => {
   const wheelRef = useRef<HTMLDivElement | null>(null);
   const settleTimerRef = useRef<number | null>(null);
-  const wheelRows = useMemo(
-    () => [null, ...values, null] as Array<number | null>,
-    [values],
-  );
 
   const clearSettleTimer = () => {
     if (settleTimerRef.current) {
@@ -37,6 +33,7 @@ const DateWheelColumn = ({
     if (!container) return;
     const index = values.indexOf(value);
     if (index < 0) return;
+    // padding-top 1칸이 있으므로 values[i]는 scrollTop = i * HEIGHT 일 때 중앙에 온다.
     container.scrollTo({
       top: index * WHEEL_ITEM_HEIGHT,
       behavior,
@@ -77,30 +74,28 @@ const DateWheelColumn = ({
       <div
         ref={wheelRef}
         onScroll={handleScroll}
-        className="h-[87px] overflow-y-auto no-scrollbar snap-y snap-mandatory"
+        className="h-[87px] overflow-y-auto no-scrollbar snap-y snap-mandatory py-[29px]"
       >
-        {wheelRows.map((value, index) => (
+        {values.map((value) => (
           <div
-            key={`${value ?? "spacer"}-${index}`}
+            key={value}
             className="flex h-[29px] items-center justify-center snap-start"
           >
-            {value === null ? null : (
-              <button
-                type="button"
-                onClick={() => {
-                  onChange(value);
-                  scrollToValue(value, "smooth");
-                }}
-                className={`z-10 whitespace-nowrap text-12px leading-[1.4] cursor-pointer ${
-                  value === selectedValue
-                    ? "font-semibold text-neutral-gray-1"
-                    : "font-normal text-neutral-gray-4"
-                }`}
-              >
-                {formatter(value)}
-                {unit}
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => {
+                onChange(value);
+                scrollToValue(value, "smooth");
+              }}
+              className={`z-10 whitespace-nowrap text-12px leading-[1.4] cursor-pointer ${
+                value === selectedValue
+                  ? "font-semibold text-neutral-gray-1"
+                  : "font-normal text-neutral-gray-4"
+              }`}
+            >
+              {formatter(value)}
+              {unit}
+            </button>
           </div>
         ))}
       </div>

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -33,10 +33,14 @@ const ProfileEditPage = () => {
   /** 이메일 변경 인증 성공 시 발급되는 토큰 (프로필 PATCH용) */
   const [emailVerificationToken, setEmailVerificationToken] = useState("");
 
+  /** 프로필 최초 로드 시에만 폼을 채운다. refetch로 입력/이메일 인증 상태를 덮어쓰지 않는다. */
+  const hasHydratedProfileRef = useRef(false);
+
   useEffect(() => {
-    if (!profile) return;
+    if (!profile || hasHydratedProfileRef.current) return;
     setOrganizationName(profile.organizationName ?? "");
     setEmail(profile.email ?? "");
+    hasHydratedProfileRef.current = true;
   }, [profile]);
 
   const handleEditEmail = () => {

--- a/src/pages/admin/WithdrawPage.tsx
+++ b/src/pages/admin/WithdrawPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
@@ -140,7 +140,7 @@ const WithdrawPage = () => {
   const canWithdraw =
     password.trim().length > 0 && !isWithdrawing && !isWithdrawComplete;
 
-  /** 완료 모달 확인(또는 닫기) 시 세션 정리 후 로그인으로 이동 */
+  /** 완료 모달 확인(또는 닫기) 시 로그인으로 이동. 세션은 탈퇴 성공 시점에 이미 정리한다. */
   const finishWithdraw = () => {
     clearAdminSession();
     void queryClient.cancelQueries();
@@ -150,6 +150,15 @@ const WithdrawPage = () => {
       queryClient.clear();
     });
   };
+
+  // 완료 모달에서 확인하지 않고 페이지를 벗어나도 세션이 남지 않도록 언마운트 시에도 정리한다.
+  useEffect(() => {
+    return () => {
+      if (isWithdrawCompleteRef.current) {
+        clearAdminSession();
+      }
+    };
+  }, []);
 
   const toggleReason = (code: WithdrawReasonCode) => {
     setSelectedReasons((prev) => {
@@ -183,9 +192,10 @@ const WithdrawPage = () => {
       },
       {
         onSuccess: () => {
-          // 세션은 유지한 채 완료 모달만 띄운다. clear는 확인 클릭 시 수행.
+          // 탈퇴 성공 즉시 세션을 정리한다. 완료 모달만 잠깐 보여 준 뒤 확인 시 로그인으로 이동한다.
           isWithdrawCompleteRef.current = true;
           setIsWithdrawComplete(true);
+          clearAdminSession();
           setIsCompleteModalOpen(true);
         },
         onError: (error) => {


### PR DESCRIPTION
## Summary
- 프로필 수정: refetch마다 폼을 덮어쓰지 않도록 최초 로드 1회만 hydrate
- 탈퇴: 성공 즉시 세션 정리 + 언마운트 시에도 재정리해 모달 미확인 이탈 시 세션 잔존 방지
- 이용 내역 날짜 휠: spacer DOM 대신 padding으로 스크롤 인덱스 정렬

## Test plan
- [ ] 프로필 수정에서 입력 중 refetch되어도 값이 초기화되지 않는지 확인
- [ ] 탈퇴 성공 후 모달 확인 없이 뒤로가기/이탈해도 로그인 상태로 남지 않는지 확인
- [ ] 이용 내역 기간 휠에서 연/월/일 선택·스크롤이 선택값과 일치하는지 확인


Made with [Cursor](https://cursor.com)