### PR TITLE
[RTR-306] 쿠폰 등록 및 조회 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -22,6 +22,8 @@ import type {
   PublicApproveRentalResponse,
   PublicRejectRentalRequestBody,
   PublicRejectRentalResponse,
+  AdminCouponLookupResponse,
+  AdminCouponRegistrationResponse,
 } from "./admin.type";
 import { apiClient } from "../core";
 import type { AxiosResponse } from "axios";
@@ -357,3 +359,31 @@ export const requestAdminLedgerExcelDownload =
       },
     });
   };
+
+// 쿠폰 조회
+// - 쿠폰 코드로 존재 여부·사용 여부·혜택 정보를 조회
+// - couponCode: 사용자가 입력한 쿠폰 코드 (path)
+// GET /api/admin/v1/coupons/{couponCode}
+export const requestAdminCoupon = async (
+  couponCode: string,
+): Promise<AdminCouponLookupResponse> => {
+  const response = await apiClient.get<AdminCouponLookupResponse>(
+    `/api/admin/v1/coupons/${encodeURIComponent(couponCode)}`,
+  );
+  return response.data;
+};
+
+// 쿠폰 등록
+// - 조회 API에서 받은 couponId로 이용권 등록
+// - couponId: 쿠폰 ID (path), body 없음
+// POST /api/admin/v1/coupons/{couponId}/registrations
+export const registerAdminCoupon = async ({
+  couponId,
+}: {
+  couponId: string;
+}): Promise<AdminCouponRegistrationResponse> => {
+  const response = await apiClient.post<AdminCouponRegistrationResponse>(
+    `/api/admin/v1/coupons/${encodeURIComponent(couponId)}/registrations`,
+  );
+  return response.data;
+};

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -320,3 +320,36 @@ export interface AdminVerifyCodeResponse {
   rawToken?: string;
   rentalId?: number;
 }
+
+// 쿠폰 조회 응답
+// GET /api/admin/v1/coupons/{couponCode}
+export interface AdminCouponLookupResponse {
+  isExist: boolean;
+  isUsed: boolean;
+  couponId: string;
+  name: string;
+  description: string;
+  durationDays: number;
+  activeStartDay: string; // YYYY-MM-DD
+  expiresDay: string; // YYYY-MM-DD
+  guideline: string;
+}
+
+// 쿠폰 등록 응답
+// POST /api/admin/v1/coupons/{couponId}/registrations
+export interface AdminCouponRegistrationResponse {
+  organizationId: number;
+  couponRegistrationId: string;
+  couponId: string;
+  membershipPassId: string;
+}
+
+// 쿠폰 조회/등록 실패 시 공통 에러 응답
+// - 404: code 3004 (존재하지 않는 단체)
+// - 409: code 12101 (이용 불가능한 쿠폰, 등록 API)
+export interface AdminCouponErrorResponse {
+  status: string;
+  code: number;
+  message: string;
+  detail?: string;
+}

--- a/src/components/modals/membership/CouponAlertModal.tsx
+++ b/src/components/modals/membership/CouponAlertModal.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { Modal } from "../../Modal";
+
+type CouponAlertModalProps = {
+  isOpen: boolean;
+  message: ReactNode;
+  confirmText?: string;
+  onClose: () => void;
+};
+
+const CouponAlertModal = ({
+  isOpen,
+  message,
+  confirmText = "확인",
+  onClose,
+}: CouponAlertModalProps) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    showTitle={false}
+    showCloseButton={false}
+    modalClassName="!w-[338px] !rounded-[24px] !px-6 !pt-16 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+  >
+    <div className="flex w-full flex-col items-center font-[Pretendard]">
+      <p className="min-h-[56px] text-center text-20px font-semibold leading-[1.4] text-neutral-gray-1 whitespace-pre-line">
+        {message}
+      </p>
+
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-10 flex h-12 w-full max-w-[290px] items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-[0_0_4px_rgba(181,244,255,0.5)] cursor-pointer hover:bg-secondary-2 transition-colors"
+      >
+        {confirmText}
+      </button>
+    </div>
+  </Modal>
+);
+
+export default CouponAlertModal;

--- a/src/components/modals/membership/CouponRegistrationModal.tsx
+++ b/src/components/modals/membership/CouponRegistrationModal.tsx
@@ -1,58 +1,33 @@
-import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import type { AdminCouponLookupResponse } from "../../../api/admin/admin.type";
 import MembershipCouponCard from "../../membership/MembershipCouponCard";
-
-export type CouponPreview = {
-  title: string;
-  eventName: string;
-  validityPeriod: string;
-  benefitPeriod: string;
-};
-
-const DEFAULT_PREVIEW: CouponPreview = {
-  title: "2달 이용권",
-  eventName: "Retrivr 출시 이벤트",
-  validityPeriod: "26. 05. 01 ~ 26. 06. 30",
-  benefitPeriod: "등록일로부터 60일 간",
-};
+import { toCouponModalViewModel } from "../../../utils/couponDisplay";
 
 const NOTICE_ITEMS = [
   "이미 프로 멤버십을 이용 중인 경우, 현재 이용권 종료 후 혜택이 시작됩니다.",
   "관련 문의: 인스타그램 DM (@Retrivr_official)",
 ];
 
-export const lookupCouponPreview = (code: string): CouponPreview | null => {
-  const normalized = code.trim().toUpperCase();
-  if (!normalized) return null;
-  if (normalized.length < 4) return null;
-  return DEFAULT_PREVIEW;
-};
-
 type CouponRegistrationModalProps = {
   isOpen: boolean;
+  couponCode: string;
+  coupon: AdminCouponLookupResponse | null;
+  isRegistering?: boolean;
   onClose: () => void;
-  onRegister: (code: string, preview: CouponPreview) => void;
+  onRegister: () => void;
 };
 
 const CouponRegistrationModal = ({
   isOpen,
+  couponCode,
+  coupon,
+  isRegistering = false,
   onClose,
   onRegister,
 }: CouponRegistrationModalProps) => {
-  const [couponCode, setCouponCode] = useState("");
-  const preview = lookupCouponPreview(couponCode);
+  if (!isOpen || !coupon) return null;
 
-  useEffect(() => {
-    if (!isOpen) return;
-    setCouponCode("");
-  }, [isOpen]);
-
-  if (!isOpen) return null;
-
-  const handleRegister = () => {
-    if (!preview) return;
-    onRegister(couponCode.trim().toUpperCase(), preview);
-  };
+  const preview = toCouponModalViewModel(coupon);
 
   return createPortal(
     <div className="fixed inset-0 z-[999] flex items-center justify-center px-8 font-[Pretendard]">
@@ -61,6 +36,7 @@ const CouponRegistrationModal = ({
         className="absolute inset-0 bg-[rgba(217,217,217,0.48)] cursor-default"
         aria-label="모달 닫기"
         onClick={onClose}
+        disabled={isRegistering}
       />
 
       <div
@@ -81,30 +57,21 @@ const CouponRegistrationModal = ({
           <input
             type="text"
             value={couponCode}
-            onChange={(event) =>
-              setCouponCode(event.target.value.toUpperCase())
-            }
-            placeholder="쿠폰 코드를 입력해주세요"
-            className="h-12 w-full rounded-[12px] bg-neutral-gray-5 px-3.5 text-14px font-normal leading-[1.4] text-neutral-gray-2 outline-none placeholder:text-neutral-gray-3 focus:ring-2 focus:ring-primary/30"
-            autoFocus
+            readOnly
+            aria-readonly="true"
+            className="h-12 w-full rounded-[12px] bg-neutral-gray-5 px-3.5 text-14px font-normal leading-[1.4] text-neutral-gray-2 outline-none"
           />
 
           <div className="-mx-6 flex flex-col gap-6 bg-secondary-4 px-6 py-6">
-            {preview ? (
-              <MembershipCouponCard
-                title={preview.title}
-                eventName={preview.eventName}
-                period={preview.validityPeriod}
-                status="pending"
-                periodLabel="유효 기간"
-                compact
-                preview
-              />
-            ) : (
-              <p className="py-4 text-center text-14px font-normal leading-[1.4] text-neutral-gray-3">
-                쿠폰 코드를 입력하면 미리보기가 표시됩니다
-              </p>
-            )}
+            <MembershipCouponCard
+              title={preview.title}
+              eventName={preview.eventName}
+              period={preview.validityPeriod}
+              status="pending"
+              periodLabel="유효 기간"
+              compact
+              preview
+            />
 
             <div className="flex flex-col gap-2.5">
               <div className="flex flex-col gap-0.5">
@@ -112,7 +79,7 @@ const CouponRegistrationModal = ({
                   혜택 기간
                 </p>
                 <p className="text-14px font-normal leading-[1.4] text-neutral-gray-2">
-                  {preview?.benefitPeriod ?? "등록일로부터 60일 간"}
+                  {preview.benefitPeriod}
                 </p>
               </div>
 
@@ -121,7 +88,7 @@ const CouponRegistrationModal = ({
                   유효 기간
                 </p>
                 <p className="text-14px font-normal leading-[1.4] text-neutral-gray-2">
-                  {preview?.validityPeriod ?? "-"}
+                  {preview.validityPeriod}
                 </p>
               </div>
 
@@ -152,11 +119,11 @@ const CouponRegistrationModal = ({
         <div className="shrink-0 px-6 pb-6 pt-4">
           <button
             type="button"
-            onClick={handleRegister}
-            disabled={!preview}
+            onClick={onRegister}
+            disabled={isRegistering}
             className="flex h-12 w-full items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-primary transition-colors enabled:cursor-pointer enabled:hover:bg-secondary-2 disabled:cursor-not-allowed disabled:bg-neutral-gray-4"
           >
-            등록하기
+            {isRegistering ? "등록 중..." : "등록하기"}
           </button>
         </div>
       </div>

--- a/src/components/modals/membership/CouponSuccessModal.tsx
+++ b/src/components/modals/membership/CouponSuccessModal.tsx
@@ -1,0 +1,44 @@
+import { Modal } from "../../Modal";
+
+type CouponSuccessModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const CouponSuccessModal = ({ isOpen, onClose }: CouponSuccessModalProps) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    showTitle={false}
+    showCloseButton={false}
+    modalClassName="!w-[338px] !rounded-[24px] !px-6 !pt-9 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+  >
+    <div className="flex w-full flex-col items-center font-[Pretendard]">
+      <img
+        src="/icons/modal-check.svg"
+        alt=""
+        width={34}
+        height={34}
+        className="size-[34px]"
+        aria-hidden
+      />
+
+      <p className="mt-4 text-center text-20px font-semibold leading-[1.4] text-neutral-gray-1">
+        쿠폰이 등록되었어요
+      </p>
+      <p className="mt-1 text-center text-14px font-normal leading-[1.4] text-primary">
+        이용권 목록에서 등록된 쿠폰을 확인할 수 있어요
+      </p>
+
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-10 flex h-12 w-full max-w-[290px] items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-[0_0_4px_rgba(181,244,255,0.5)] cursor-pointer hover:bg-secondary-2 transition-colors"
+      >
+        확인
+      </button>
+    </div>
+  </Modal>
+);
+
+export default CouponSuccessModal;

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -23,6 +23,8 @@ import {
   requestAdminRentalSearch,
   approvePublicRental,
   rejectPublicRental,
+  requestAdminCoupon,
+  registerAdminCoupon,
 } from "../../api/admin/admin.api";
 import type {
   AdminCreateItemRequest,
@@ -366,5 +368,23 @@ export const useVerifyAdminCode = () => {
 export const useVerifyAdminCodeByAdmin = () => {
   return useMutation({
     mutationFn: (body: AdminVerifyCodeRequestBody) => verifyAdminCodeByAdmin(body),
+  });
+};
+
+// 쿠폰 조회
+// - 멤버십 페이지에서 쿠폰 코드로 미리보기/등록 모달 진입 전 검증
+// GET /api/admin/v1/coupons/{couponCode}
+export const useRequestAdminCoupon = () => {
+  return useMutation({
+    mutationFn: (couponCode: string) => requestAdminCoupon(couponCode),
+  });
+};
+
+// 쿠폰 등록
+// - 쿠폰 등록 모달에서 조회된 couponId로 이용권 등록
+// POST /api/admin/v1/coupons/{couponId}/registrations
+export const useRegisterAdminCoupon = () => {
+  return useMutation({
+    mutationFn: (couponId: string) => registerAdminCoupon({ couponId }),
   });
 };

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -1,13 +1,25 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";
-import { lookupCouponPreview } from "../../components/modals/membership/CouponRegistrationModal";
+import CouponAlertModal from "../../components/modals/membership/CouponAlertModal";
+import CouponRegistrationModal from "../../components/modals/membership/CouponRegistrationModal";
+import CouponSuccessModal from "../../components/modals/membership/CouponSuccessModal";
 import MembershipCouponCard from "../../components/membership/MembershipCouponCard";
 import MembershipProBadge from "../../components/membership/MembershipProBadge";
+import {
+  useRegisterAdminCoupon,
+  useRequestAdminCoupon,
+} from "../../hooks/queries/useAdminQueries";
+import type {
+  AdminCouponErrorResponse,
+  AdminCouponLookupResponse,
+} from "../../api/admin/admin.type";
 
 type BillingCycle = "monthly" | "yearly";
+type CouponAlertType = "notFound" | "alreadyUsed";
 
 const ACTIVE_PLAN = {
   title: "월간 이용권",
@@ -15,6 +27,11 @@ const ACTIVE_PLAN = {
   priceUnit: "/월",
   nextBillingDate: "26. 05. 01",
   usageType: "월간 이용권",
+};
+
+const COUPON_ALERT_MESSAGES: Record<CouponAlertType, string> = {
+  notFound: "쿠폰 번호를\n다시 확인해주세요.",
+  alreadyUsed: "이미 사용된 쿠폰이예요.",
 };
 
 const SUBSCRIPTION_PLANS: Record<
@@ -40,17 +57,37 @@ const MENU_ITEMS = [
 
 const COMING_SOON_MESSAGE = "개발 예정입니다.";
 
+const getCouponErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as AdminCouponErrorResponse | undefined;
+    if (data?.message) return data.message;
+  }
+  return fallback;
+};
+
 const MembershipPage = () => {
   const navigate = useNavigate();
   const [billingCycle, setBillingCycle] = useState<BillingCycle>("monthly");
   const [couponCode, setCouponCode] = useState("");
+  const [lookedUpCouponCode, setLookedUpCouponCode] = useState("");
+  const [lookedUpCoupon, setLookedUpCoupon] =
+    useState<AdminCouponLookupResponse | null>(null);
+  const [isCouponModalOpen, setIsCouponModalOpen] = useState(false);
+  const [couponAlertType, setCouponAlertType] =
+    useState<CouponAlertType | null>(null);
+  const [isCouponSuccessModalOpen, setIsCouponSuccessModalOpen] =
+    useState(false);
   const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
     null,
   );
 
+  const lookupCouponMutation = useRequestAdminCoupon();
+  const registerCouponMutation = useRegisterAdminCoupon();
+
   const selectedPlan = SUBSCRIPTION_PLANS[billingCycle];
-  const couponPreview = lookupCouponPreview(couponCode);
-  const canRegisterCoupon = couponPreview !== null;
+  const trimmedCouponCode = couponCode.trim();
+  const canLookupCoupon =
+    trimmedCouponCode.length > 0 && !lookupCouponMutation.isPending;
 
   const handleComingSoon = () => {
     alert(COMING_SOON_MESSAGE);
@@ -72,13 +109,58 @@ const MembershipPage = () => {
     handleComingSoon();
   };
 
+  const handleCloseCouponModal = () => {
+    if (registerCouponMutation.isPending) return;
+    setIsCouponModalOpen(false);
+    setLookedUpCoupon(null);
+    setLookedUpCouponCode("");
+  };
+
+  const handleLookupCoupon = () => {
+    if (!trimmedCouponCode || lookupCouponMutation.isPending) return;
+
+    lookupCouponMutation.mutate(trimmedCouponCode, {
+      onSuccess: (coupon) => {
+        if (!coupon.isExist) {
+          setCouponAlertType("notFound");
+          return;
+        }
+        if (coupon.isUsed) {
+          setCouponAlertType("alreadyUsed");
+          return;
+        }
+        setLookedUpCouponCode(trimmedCouponCode);
+        setLookedUpCoupon(coupon);
+        setIsCouponModalOpen(true);
+      },
+      onError: (error) => {
+        setConfirmModalMessage(
+          getCouponErrorMessage(error, "쿠폰 조회에 실패했어요"),
+        );
+      },
+    });
+  };
+
   const handleRegisterCoupon = () => {
-    if (!couponPreview) {
-      setConfirmModalMessage("유효하지 않은 쿠폰 번호예요");
-      return;
-    }
-    setCouponCode("");
-    setConfirmModalMessage("쿠폰이 등록되었어요");
+    if (!lookedUpCoupon || registerCouponMutation.isPending) return;
+
+    registerCouponMutation.mutate(lookedUpCoupon.couponId, {
+      onSuccess: () => {
+        setIsCouponModalOpen(false);
+        setLookedUpCoupon(null);
+        setLookedUpCouponCode("");
+        setCouponCode("");
+        setIsCouponSuccessModalOpen(true);
+      },
+      onError: (error) => {
+        setIsCouponModalOpen(false);
+        setLookedUpCoupon(null);
+        setLookedUpCouponCode("");
+        setConfirmModalMessage(
+          getCouponErrorMessage(error, "쿠폰 등록에 실패했어요"),
+        );
+      },
+    });
   };
 
   return (
@@ -235,16 +317,38 @@ const MembershipPage = () => {
               />
               <button
                 type="button"
-                onClick={handleRegisterCoupon}
-                disabled={!canRegisterCoupon}
+                onClick={handleLookupCoupon}
+                disabled={!canLookupCoupon}
                 className="flex h-12 w-20 shrink-0 items-center justify-center rounded-[12px] text-16px font-semibold text-neutral-white transition-colors enabled:cursor-pointer enabled:bg-primary enabled:hover:bg-secondary-2 disabled:cursor-not-allowed disabled:bg-neutral-gray-4"
               >
-                등록
+                {lookupCouponMutation.isPending ? "조회중" : "등록"}
               </button>
             </div>
           </div>
         </section>
       </div>
+
+      <CouponRegistrationModal
+        isOpen={isCouponModalOpen}
+        couponCode={lookedUpCouponCode}
+        coupon={lookedUpCoupon}
+        isRegistering={registerCouponMutation.isPending}
+        onClose={handleCloseCouponModal}
+        onRegister={handleRegisterCoupon}
+      />
+
+      <CouponAlertModal
+        isOpen={couponAlertType !== null}
+        message={
+          couponAlertType ? COUPON_ALERT_MESSAGES[couponAlertType] : ""
+        }
+        onClose={() => setCouponAlertType(null)}
+      />
+
+      <CouponSuccessModal
+        isOpen={isCouponSuccessModalOpen}
+        onClose={() => setIsCouponSuccessModalOpen(false)}
+      />
 
       <ConfirmModal
         isOpen={confirmModalMessage !== null}

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
-import ConfirmModal from "../../components/modals/ConfirmModal";
 import CouponAlertModal from "../../components/modals/membership/CouponAlertModal";
 import CouponRegistrationModal from "../../components/modals/membership/CouponRegistrationModal";
 import CouponSuccessModal from "../../components/modals/membership/CouponSuccessModal";
@@ -13,13 +11,14 @@ import {
   useRegisterAdminCoupon,
   useRequestAdminCoupon,
 } from "../../hooks/queries/useAdminQueries";
-import type {
-  AdminCouponErrorResponse,
-  AdminCouponLookupResponse,
-} from "../../api/admin/admin.type";
+import type { AdminCouponLookupResponse } from "../../api/admin/admin.type";
 
 type BillingCycle = "monthly" | "yearly";
-type CouponAlertType = "notFound" | "alreadyUsed";
+type CouponAlertType =
+  | "notFound"
+  | "alreadyUsed"
+  | "lookupFailed"
+  | "registerFailed";
 
 const ACTIVE_PLAN = {
   title: "월간 이용권",
@@ -32,6 +31,8 @@ const ACTIVE_PLAN = {
 const COUPON_ALERT_MESSAGES: Record<CouponAlertType, string> = {
   notFound: "쿠폰 번호를\n다시 확인해주세요.",
   alreadyUsed: "이미 사용된 쿠폰이예요.",
+  lookupFailed: "쿠폰 조회에 실패했습니다.\n다시 시도해주세요.",
+  registerFailed: "쿠폰 등록에 실패했습니다.\n다시 시도해주세요.",
 };
 
 const SUBSCRIPTION_PLANS: Record<
@@ -57,14 +58,6 @@ const MENU_ITEMS = [
 
 const COMING_SOON_MESSAGE = "개발 예정입니다.";
 
-const getCouponErrorMessage = (error: unknown, fallback: string) => {
-  if (axios.isAxiosError(error)) {
-    const data = error.response?.data as AdminCouponErrorResponse | undefined;
-    if (data?.message) return data.message;
-  }
-  return fallback;
-};
-
 const MembershipPage = () => {
   const navigate = useNavigate();
   const [billingCycle, setBillingCycle] = useState<BillingCycle>("monthly");
@@ -77,9 +70,6 @@ const MembershipPage = () => {
     useState<CouponAlertType | null>(null);
   const [isCouponSuccessModalOpen, setIsCouponSuccessModalOpen] =
     useState(false);
-  const [confirmModalMessage, setConfirmModalMessage] = useState<string | null>(
-    null,
-  );
 
   const lookupCouponMutation = useRequestAdminCoupon();
   const registerCouponMutation = useRegisterAdminCoupon();
@@ -133,10 +123,8 @@ const MembershipPage = () => {
         setLookedUpCoupon(coupon);
         setIsCouponModalOpen(true);
       },
-      onError: (error) => {
-        setConfirmModalMessage(
-          getCouponErrorMessage(error, "쿠폰 조회에 실패했어요"),
-        );
+      onError: () => {
+        setCouponAlertType("lookupFailed");
       },
     });
   };
@@ -152,13 +140,11 @@ const MembershipPage = () => {
         setCouponCode("");
         setIsCouponSuccessModalOpen(true);
       },
-      onError: (error) => {
+      onError: () => {
         setIsCouponModalOpen(false);
         setLookedUpCoupon(null);
         setLookedUpCouponCode("");
-        setConfirmModalMessage(
-          getCouponErrorMessage(error, "쿠폰 등록에 실패했어요"),
-        );
+        setCouponAlertType("registerFailed");
       },
     });
   };
@@ -348,13 +334,6 @@ const MembershipPage = () => {
       <CouponSuccessModal
         isOpen={isCouponSuccessModalOpen}
         onClose={() => setIsCouponSuccessModalOpen(false)}
-      />
-
-      <ConfirmModal
-        isOpen={confirmModalMessage !== null}
-        onClose={() => setConfirmModalMessage(null)}
-        message={confirmModalMessage ?? ""}
-        confirmText="확인"
       />
     </Layout>
   );

--- a/src/utils/couponDisplay.ts
+++ b/src/utils/couponDisplay.ts
@@ -1,0 +1,36 @@
+import type { AdminCouponLookupResponse } from "../api/admin/admin.type";
+
+/** YYYY-MM-DD → YY. MM. DD */
+export const formatCouponDay = (day: string): string => {
+  const [year, month, date] = day.split("-");
+  if (!year || !month || !date) return day;
+  return `${year.slice(-2)}. ${month}. ${date}`;
+};
+
+export const formatCouponValidityPeriod = (
+  activeStartDay: string,
+  expiresDay: string,
+): string =>
+  `${formatCouponDay(activeStartDay)} ~ ${formatCouponDay(expiresDay)}`;
+
+export const formatCouponBenefitPeriod = (durationDays: number): string =>
+  `등록일로부터 ${durationDays}일 간`;
+
+export type CouponModalViewModel = {
+  title: string;
+  eventName: string;
+  validityPeriod: string;
+  benefitPeriod: string;
+};
+
+export const toCouponModalViewModel = (
+  coupon: AdminCouponLookupResponse,
+): CouponModalViewModel => ({
+  title: coupon.name,
+  eventName: coupon.description,
+  validityPeriod: formatCouponValidityPeriod(
+    coupon.activeStartDay,
+    coupon.expiresDay,
+  ),
+  benefitPeriod: formatCouponBenefitPeriod(coupon.durationDays),
+});


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- 쿠폰 조회(GET) / 등록(POST) API·타입·React Query 훅 추가
- MembershipPage: 등록 버튼 → 조회 API → 등록 모달 → 등록 API 플로우 연동
- CouponRegistrationModal을 조회 응답 기준으로 렌더링하도록 개편
- CouponAlertModal(미존재/사용됨/조회·등록 실패) · CouponSuccessModal 추가

## ⭐ PR Point (To Reviewer)

- 조회 성공 후 couponId로 등록 API 호출
- 알림 모달은 CouponAlertModal에 message만 교체해 재사용

## 📷 Screenshot

## 🔔 ETC

- Bugbot: no findings
- develop 머지 요청 (main PR 없음)


Made with [Cursor](https://cursor.com)