### PR TITLE
[RTR-314] 현재 멤버쉽 상태 조회 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -24,6 +24,7 @@ import type {
   PublicRejectRentalResponse,
   AdminCouponLookupResponse,
   AdminCouponRegistrationResponse,
+  AdminMembershipResponse,
 } from "./admin.type";
 import { apiClient } from "../core";
 import type { AxiosResponse } from "axios";
@@ -387,3 +388,14 @@ export const registerAdminCoupon = async ({
   );
   return response.data;
 };
+
+// 현재 멤버십 상태 조회
+// - 이용권 목록(쿠폰/구독) 화면에서 현재 이용권 정보를 표시
+// GET /api/admin/v1/membership
+export const requestAdminMembership =
+  async (): Promise<AdminMembershipResponse> => {
+    const response = await apiClient.get<AdminMembershipResponse>(
+      "/api/admin/v1/membership",
+    );
+    return response.data;
+  };

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -353,3 +353,35 @@ export interface AdminCouponErrorResponse {
   message: string;
   detail?: string;
 }
+
+// 현재 멤버십 상태 조회 응답
+// GET /api/admin/v1/membership
+export interface AdminMembershipCouponInfo {
+  couponName: string;
+  couponDescription: string;
+}
+
+export interface AdminMembershipSubscriptionInfo {
+  subscriptionName: string;
+}
+
+export interface AdminMembershipResponse {
+  subscribed: boolean;
+  level: string; // 예: "PREMIUM"
+  passType: string;
+  couponInfo?: AdminMembershipCouponInfo | null;
+  subscriptionInfo?: AdminMembershipSubscriptionInfo | null;
+  startAt: string; // YYYY-MM-DD
+  endAt: string; // YYYY-MM-DD
+  nextBillingAt?: string; // YYYY-MM-DD
+}
+
+// 멤버십 조회 실패 시 공통 에러 응답
+// - 400: code 12202 (이용권에서 구독 정보를 가져올 수 없음)
+// - 404: code 3004 (존재하지 않는 단체)
+export interface AdminMembershipErrorResponse {
+  status: string;
+  code: number;
+  message: string;
+  detail?: string;
+}

--- a/src/components/membership/CouponVoucherPanel.tsx
+++ b/src/components/membership/CouponVoucherPanel.tsx
@@ -1,26 +1,64 @@
-import {
-  COUPON_USAGE_GUIDE,
-  COUPON_VOUCHERS,
-} from "../../types/voucherList";
+import { COUPON_USAGE_GUIDE } from "../../types/voucherList";
+import { useAdminMembership } from "../../hooks/queries/useAdminQueries";
+import { formatCouponValidityPeriod } from "../../utils/couponDisplay";
+import type { MembershipCouponStatus } from "./MembershipStatusBadge";
 import MembershipCouponCard from "./MembershipCouponCard";
 import UsageGuideCard from "./UsageGuideCard";
 
-const CouponVoucherPanel = () => (
-  <div className="flex flex-col gap-4">
-    <div className="flex flex-col gap-2.5">
-      {COUPON_VOUCHERS.map((voucher) => (
-        <MembershipCouponCard
-          key={voucher.id}
-          title={voucher.title}
-          eventName={voucher.eventName}
-          status={voucher.status}
-          footerText={voucher.footerText}
-          compact
-        />
-      ))}
+const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
+
+const resolveCouponStatus = (subscribed: boolean): MembershipCouponStatus =>
+  subscribed ? "active" : "pending";
+
+const CouponVoucherPanel = () => {
+  const { data, isLoading, isError, isSuccess } = useAdminMembership();
+
+  const showEmptyState = !isLoading && (isError || !isSuccess);
+  const usagePeriod =
+    data?.startAt && data?.endAt
+      ? formatCouponValidityPeriod(data.startAt, data.endAt)
+      : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {isLoading ? (
+        <div className="flex min-h-[180px] items-center justify-center">
+          <p className="text-14px font-normal leading-[1.4] text-neutral-gray-3">
+            이용권을 불러오는 중이에요
+          </p>
+        </div>
+      ) : null}
+
+      {showEmptyState ? (
+        <div className="flex min-h-[180px] items-center justify-center">
+          <p className="text-center text-14px font-normal leading-[1.4] text-neutral-gray-3">
+            {EMPTY_MEMBERSHIP_MESSAGE}
+          </p>
+        </div>
+      ) : null}
+
+      {isSuccess && data ? (
+        <div className="flex flex-col gap-2.5">
+          <MembershipCouponCard
+            title={
+              data.couponInfo?.couponName ||
+              data.subscriptionInfo?.subscriptionName ||
+              data.passType ||
+              "이용권"
+            }
+            eventName={data.couponInfo?.couponDescription}
+            status={resolveCouponStatus(data.subscribed)}
+            footerText={
+              usagePeriod ? `사용 기간: ${usagePeriod}` : undefined
+            }
+            compact
+          />
+        </div>
+      ) : null}
+
+      <UsageGuideCard items={COUPON_USAGE_GUIDE} />
     </div>
-    <UsageGuideCard items={COUPON_USAGE_GUIDE} />
-  </div>
-);
+  );
+};
 
 export default CouponVoucherPanel;

--- a/src/components/membership/CouponVoucherPanel.tsx
+++ b/src/components/membership/CouponVoucherPanel.tsx
@@ -7,13 +7,27 @@ import UsageGuideCard from "./UsageGuideCard";
 
 const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
 
-const resolveCouponStatus = (subscribed: boolean): MembershipCouponStatus =>
-  subscribed ? "active" : "pending";
+const resolveCouponStatus = ({
+  subscribed,
+  hasSubscription,
+}: {
+  subscribed: boolean;
+  hasSubscription: boolean;
+}): MembershipCouponStatus => {
+  // 구독 이용권이 함께 있으면 쿠폰은 대기, 아니면 구독 여부로 사용중/대기 구분
+  if (hasSubscription) return "pending";
+  return subscribed ? "active" : "pending";
+};
 
 const CouponVoucherPanel = () => {
   const { data, isLoading, isError, isSuccess } = useAdminMembership();
 
-  const showEmptyState = !isLoading && (isError || !isSuccess);
+  const couponInfo = data?.couponInfo;
+  const hasCoupon =
+    Boolean(couponInfo?.couponName) || Boolean(couponInfo?.couponDescription);
+  const showEmptyState =
+    !isLoading && (isError || !isSuccess || (isSuccess && !hasCoupon));
+
   const usagePeriod =
     data?.startAt && data?.endAt
       ? formatCouponValidityPeriod(data.startAt, data.endAt)
@@ -37,17 +51,17 @@ const CouponVoucherPanel = () => {
         </div>
       ) : null}
 
-      {isSuccess && data ? (
+      {isSuccess && data && hasCoupon && couponInfo ? (
         <div className="flex flex-col gap-2.5">
           <MembershipCouponCard
-            title={
-              data.couponInfo?.couponName ||
-              data.subscriptionInfo?.subscriptionName ||
-              data.passType ||
-              "이용권"
-            }
-            eventName={data.couponInfo?.couponDescription}
-            status={resolveCouponStatus(data.subscribed)}
+            title={couponInfo.couponName || "쿠폰 이용권"}
+            eventName={couponInfo.couponDescription}
+            status={resolveCouponStatus({
+              subscribed: data.subscribed,
+              hasSubscription: Boolean(
+                data.subscriptionInfo?.subscriptionName,
+              ),
+            })}
             footerText={
               usagePeriod ? `사용 기간: ${usagePeriod}` : undefined
             }

--- a/src/components/membership/CouponVoucherPanel.tsx
+++ b/src/components/membership/CouponVoucherPanel.tsx
@@ -1,96 +1,26 @@
-import { COUPON_USAGE_GUIDE } from "../../types/voucherList";
-import { useAdminMembership } from "../../hooks/queries/useAdminQueries";
 import {
-  formatCouponDay,
-  formatCouponValidityPeriod,
-} from "../../utils/couponDisplay";
-import type { MembershipCouponStatus } from "./MembershipStatusBadge";
+  COUPON_USAGE_GUIDE,
+  COUPON_VOUCHERS,
+} from "../../types/voucherList";
 import MembershipCouponCard from "./MembershipCouponCard";
 import UsageGuideCard from "./UsageGuideCard";
 
-const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
-
-const resolveCouponStatus = (
-  hasSubscription: boolean,
-): MembershipCouponStatus =>
-  // 구독 이용권이 있으면 쿠폰은 대기, 쿠폰만 있으면 등록 즉시 사용중
-  hasSubscription ? "pending" : "active";
-
-const resolveCouponFooterText = ({
-  status,
-  startAt,
-  endAt,
-  nextBillingAt,
-}: {
-  status: MembershipCouponStatus;
-  startAt?: string;
-  endAt?: string;
-  nextBillingAt?: string;
-}): string | undefined => {
-  if (status === "pending") {
-    if (nextBillingAt) {
-      return `${formatCouponDay(nextBillingAt)} 활성화 예정`;
-    }
-    return undefined;
-  }
-
-  if (startAt && endAt) {
-    return `사용 기간: ${formatCouponValidityPeriod(startAt, endAt)}`;
-  }
-  return undefined;
-};
-
-const CouponVoucherPanel = () => {
-  const { data, isLoading, isError, isSuccess } = useAdminMembership();
-
-  const couponInfo = data?.couponInfo;
-  const hasCoupon =
-    Boolean(couponInfo?.couponName) || Boolean(couponInfo?.couponDescription);
-  const hasSubscription = Boolean(data?.subscriptionInfo?.subscriptionName);
-  const showEmptyState =
-    !isLoading && (isError || !isSuccess || (isSuccess && !hasCoupon));
-
-  const status = resolveCouponStatus(hasSubscription);
-  const footerText = resolveCouponFooterText({
-    status,
-    startAt: data?.startAt,
-    endAt: data?.endAt,
-    nextBillingAt: data?.nextBillingAt,
-  });
-
-  return (
-    <div className="flex flex-col gap-4">
-      {isLoading ? (
-        <div className="flex min-h-[180px] items-center justify-center">
-          <p className="text-14px font-normal leading-[1.4] text-neutral-gray-3">
-            이용권을 불러오는 중이에요
-          </p>
-        </div>
-      ) : null}
-
-      {showEmptyState ? (
-        <div className="flex min-h-[180px] items-center justify-center">
-          <p className="text-center text-14px font-normal leading-[1.4] text-neutral-gray-3">
-            {EMPTY_MEMBERSHIP_MESSAGE}
-          </p>
-        </div>
-      ) : null}
-
-      {isSuccess && data && hasCoupon && couponInfo ? (
-        <div className="flex flex-col gap-2.5">
-          <MembershipCouponCard
-            title={couponInfo.couponName || "쿠폰 이용권"}
-            eventName={couponInfo.couponDescription}
-            status={status}
-            footerText={footerText}
-            compact
-          />
-        </div>
-      ) : null}
-
-      <UsageGuideCard items={COUPON_USAGE_GUIDE} />
+const CouponVoucherPanel = () => (
+  <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-2.5">
+      {COUPON_VOUCHERS.map((voucher) => (
+        <MembershipCouponCard
+          key={voucher.id}
+          title={voucher.title}
+          eventName={voucher.eventName}
+          status={voucher.status}
+          footerText={voucher.footerText}
+          compact
+        />
+      ))}
     </div>
-  );
-};
+    <UsageGuideCard items={COUPON_USAGE_GUIDE} />
+  </div>
+);
 
 export default CouponVoucherPanel;

--- a/src/components/membership/CouponVoucherPanel.tsx
+++ b/src/components/membership/CouponVoucherPanel.tsx
@@ -1,22 +1,43 @@
 import { COUPON_USAGE_GUIDE } from "../../types/voucherList";
 import { useAdminMembership } from "../../hooks/queries/useAdminQueries";
-import { formatCouponValidityPeriod } from "../../utils/couponDisplay";
+import {
+  formatCouponDay,
+  formatCouponValidityPeriod,
+} from "../../utils/couponDisplay";
 import type { MembershipCouponStatus } from "./MembershipStatusBadge";
 import MembershipCouponCard from "./MembershipCouponCard";
 import UsageGuideCard from "./UsageGuideCard";
 
 const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
 
-const resolveCouponStatus = ({
-  subscribed,
-  hasSubscription,
+const resolveCouponStatus = (
+  hasSubscription: boolean,
+): MembershipCouponStatus =>
+  // 구독 이용권이 있으면 쿠폰은 대기, 쿠폰만 있으면 등록 즉시 사용중
+  hasSubscription ? "pending" : "active";
+
+const resolveCouponFooterText = ({
+  status,
+  startAt,
+  endAt,
+  nextBillingAt,
 }: {
-  subscribed: boolean;
-  hasSubscription: boolean;
-}): MembershipCouponStatus => {
-  // 구독 이용권이 함께 있으면 쿠폰은 대기, 아니면 구독 여부로 사용중/대기 구분
-  if (hasSubscription) return "pending";
-  return subscribed ? "active" : "pending";
+  status: MembershipCouponStatus;
+  startAt?: string;
+  endAt?: string;
+  nextBillingAt?: string;
+}): string | undefined => {
+  if (status === "pending") {
+    if (nextBillingAt) {
+      return `${formatCouponDay(nextBillingAt)} 활성화 예정`;
+    }
+    return undefined;
+  }
+
+  if (startAt && endAt) {
+    return `사용 기간: ${formatCouponValidityPeriod(startAt, endAt)}`;
+  }
+  return undefined;
 };
 
 const CouponVoucherPanel = () => {
@@ -25,13 +46,17 @@ const CouponVoucherPanel = () => {
   const couponInfo = data?.couponInfo;
   const hasCoupon =
     Boolean(couponInfo?.couponName) || Boolean(couponInfo?.couponDescription);
+  const hasSubscription = Boolean(data?.subscriptionInfo?.subscriptionName);
   const showEmptyState =
     !isLoading && (isError || !isSuccess || (isSuccess && !hasCoupon));
 
-  const usagePeriod =
-    data?.startAt && data?.endAt
-      ? formatCouponValidityPeriod(data.startAt, data.endAt)
-      : null;
+  const status = resolveCouponStatus(hasSubscription);
+  const footerText = resolveCouponFooterText({
+    status,
+    startAt: data?.startAt,
+    endAt: data?.endAt,
+    nextBillingAt: data?.nextBillingAt,
+  });
 
   return (
     <div className="flex flex-col gap-4">
@@ -56,15 +81,8 @@ const CouponVoucherPanel = () => {
           <MembershipCouponCard
             title={couponInfo.couponName || "쿠폰 이용권"}
             eventName={couponInfo.couponDescription}
-            status={resolveCouponStatus({
-              subscribed: data.subscribed,
-              hasSubscription: Boolean(
-                data.subscriptionInfo?.subscriptionName,
-              ),
-            })}
-            footerText={
-              usagePeriod ? `사용 기간: ${usagePeriod}` : undefined
-            }
+            status={status}
+            footerText={footerText}
             compact
           />
         </div>

--- a/src/components/membership/SubscriptionVoucherPanel.tsx
+++ b/src/components/membership/SubscriptionVoucherPanel.tsx
@@ -1,63 +1,108 @@
 import {
   SUBSCRIPTION_USAGE_GUIDE,
-  SUBSCRIPTION_VOUCHER,
 } from "../../types/voucherList";
+import { useAdminMembership } from "../../hooks/queries/useAdminQueries";
+import { formatCouponDay } from "../../utils/couponDisplay";
 import UsageGuideCard from "./UsageGuideCard";
+
+const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
 
 type SubscriptionVoucherPanelProps = {
   onCancelSubscription?: () => void;
 };
 
+const isCouponPassType = (passType?: string): boolean =>
+  Boolean(passType && /coupon/i.test(passType));
+
+const resolveStatusLabel = (isPausedForCoupon: boolean): string =>
+  // 현재 패스가 쿠폰일 때만 구독 일시중지 (대기 쿠폰만 있는 경우는 이용중)
+  isPausedForCoupon ? "일시중지" : "이용중";
+
+const resolveDescription = ({
+  isPausedForCoupon,
+  nextBillingAt,
+}: {
+  isPausedForCoupon: boolean;
+  nextBillingAt?: string;
+}): string | undefined => {
+  if (!nextBillingAt) return undefined;
+
+  const billingDay = formatCouponDay(nextBillingAt);
+
+  if (isPausedForCoupon) {
+    return `등록된 쿠폰 이용권을 모두 사용하면\n${billingDay}부터 자동 결제가 다시 진행돼요.`;
+  }
+
+  return `다음 결제 예정일: ${billingDay}`;
+};
+
 const SubscriptionVoucherPanel = ({
   onCancelSubscription,
-}: SubscriptionVoucherPanelProps) => (
-  <div className="flex flex-col gap-4">
-    <article className="flex flex-col rounded-2xl bg-neutral-white px-[26px] py-6 shadow-[0px_0px_16px_-6px_rgba(0,0,0,0.2)]">
-      <div className="flex items-center gap-[5px]">
-        <h2 className="text-16px font-bold leading-normal text-neutral-gray-1">
-          {SUBSCRIPTION_VOUCHER.title}
-        </h2>
-        <span className="inline-flex h-[18px] items-center justify-center rounded-[9px] border-[0.5px] border-secondary-2 bg-neutral-gray-5 px-[7px]">
-          <span className="text-10px font-bold leading-[1.3] text-secondary-2">
-            {SUBSCRIPTION_VOUCHER.statusLabel}
-          </span>
-        </span>
-      </div>
+}: SubscriptionVoucherPanelProps) => {
+  const { data, isLoading, isError, isSuccess } = useAdminMembership();
 
-      <p className="mt-2 whitespace-pre-line text-12px font-normal leading-[1.4] text-neutral-gray-3">
-        {SUBSCRIPTION_VOUCHER.description}
-      </p>
+  const subscriptionName = data?.subscriptionInfo?.subscriptionName?.trim();
+  const hasSubscription = Boolean(subscriptionName);
+  const isPausedForCoupon = isCouponPassType(data?.passType);
+  const showEmptyState =
+    !isLoading && (isError || !isSuccess || (isSuccess && !hasSubscription));
 
-      <div className="mt-4 flex h-[61px] w-full items-center justify-between rounded-[7.5px] border border-primary bg-secondary-4 pl-5 pr-[18px]">
-        <span className="text-18px font-bold leading-normal text-primary">
-          {SUBSCRIPTION_VOUCHER.durationLabel}
-        </span>
-        <div className="flex items-center gap-1.5">
-          <span className="text-12px font-normal leading-[1.4] text-neutral-gray-4 line-through">
-            {SUBSCRIPTION_VOUCHER.originalPrice}
-          </span>
-          <p className="text-14px font-bold leading-5 text-primary">
-            <span className="font-semibold text-neutral-gray-1">
-              {SUBSCRIPTION_VOUCHER.priceAmount}
-            </span>
-            <span className="font-medium text-neutral-gray-3">
-              {SUBSCRIPTION_VOUCHER.priceUnit}
-            </span>
+  const statusLabel = resolveStatusLabel(isPausedForCoupon);
+  const description = resolveDescription({
+    isPausedForCoupon,
+    nextBillingAt: data?.nextBillingAt,
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      {isLoading ? (
+        <div className="flex min-h-[180px] items-center justify-center">
+          <p className="text-14px font-normal leading-[1.4] text-neutral-gray-3">
+            이용권을 불러오는 중이에요
           </p>
         </div>
-      </div>
+      ) : null}
 
-      <button
-        type="button"
-        onClick={onCancelSubscription}
-        className="mt-4 self-end text-12px font-medium leading-[1.5] text-neutral-gray-3 underline cursor-pointer"
-      >
-        구독 해지
-      </button>
-    </article>
+      {showEmptyState ? (
+        <div className="flex min-h-[180px] items-center justify-center">
+          <p className="text-center text-14px font-normal leading-[1.4] text-neutral-gray-3">
+            {EMPTY_MEMBERSHIP_MESSAGE}
+          </p>
+        </div>
+      ) : null}
 
-    <UsageGuideCard items={SUBSCRIPTION_USAGE_GUIDE} />
-  </div>
-);
+      {isSuccess && data && hasSubscription && subscriptionName ? (
+        <article className="flex flex-col rounded-2xl bg-neutral-white px-[26px] py-6 shadow-[0px_0px_16px_-6px_rgba(0,0,0,0.2)]">
+          <div className="flex items-center gap-[5px]">
+            <h2 className="text-16px font-bold leading-normal text-neutral-gray-1">
+              {subscriptionName}
+            </h2>
+            <span className="inline-flex h-[18px] items-center justify-center rounded-[9px] border-[0.5px] border-secondary-2 bg-neutral-gray-5 px-[7px]">
+              <span className="text-10px font-bold leading-[1.3] text-secondary-2">
+                {statusLabel}
+              </span>
+            </span>
+          </div>
+
+          {description ? (
+            <p className="mt-2 whitespace-pre-line text-12px font-normal leading-[1.4] text-neutral-gray-3">
+              {description}
+            </p>
+          ) : null}
+
+          <button
+            type="button"
+            onClick={onCancelSubscription}
+            className="mt-4 self-end text-12px font-medium leading-[1.5] text-neutral-gray-3 underline cursor-pointer"
+          >
+            구독 해지
+          </button>
+        </article>
+      ) : null}
+
+      <UsageGuideCard items={SUBSCRIPTION_USAGE_GUIDE} />
+    </div>
+  );
+};
 
 export default SubscriptionVoucherPanel;

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -25,10 +25,12 @@ import {
   rejectPublicRental,
   requestAdminCoupon,
   registerAdminCoupon,
+  requestAdminMembership,
 } from "../../api/admin/admin.api";
 import type {
   AdminCreateItemRequest,
   AdminItemListResponse,
+  AdminMembershipResponse,
   AdminUpdateItemRequest,
   AdminUpdateReturnDueDateRequestBody,
   AdminVerifyCodeRequestBody,
@@ -386,5 +388,16 @@ export const useRequestAdminCoupon = () => {
 export const useRegisterAdminCoupon = () => {
   return useMutation({
     mutationFn: (couponId: string) => registerAdminCoupon({ couponId }),
+  });
+};
+
+// 현재 멤버십 상태 조회
+// - 이용권 목록 > 쿠폰 이용권 탭 등에서 사용
+// GET /api/admin/v1/membership
+export const useAdminMembership = () => {
+  return useQuery<AdminMembershipResponse>({
+    queryKey: ["adminMembership"],
+    queryFn: requestAdminMembership,
+    retry: false,
   });
 };

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -386,13 +386,17 @@ export const useRequestAdminCoupon = () => {
 // - 쿠폰 등록 모달에서 조회된 couponId로 이용권 등록
 // POST /api/admin/v1/coupons/{couponId}/registrations
 export const useRegisterAdminCoupon = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (couponId: string) => registerAdminCoupon({ couponId }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["adminMembership"] });
+    },
   });
 };
 
 // 현재 멤버십 상태 조회
-// - 이용권 목록 > 쿠폰 이용권 탭 등에서 사용
+// - 멤버십 이용 현황, 이용권 목록 > 구독 이용권 탭 등에서 사용
 // GET /api/admin/v1/membership
 export const useAdminMembership = () => {
   return useQuery<AdminMembershipResponse>({

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -27,8 +27,8 @@ type CouponAlertType =
   | "lookupFailed"
   | "registerFailed";
 
-const EMPTY_USAGE_TYPE = "이용 중인 이용권이 없습니다.";
-const VOUCHER_CARD_PLACEHOLDER_CLASS = "min-h-[88px]";
+const EMPTY_MEMBERSHIP_GUIDE =
+  "현재 이용 중인 이용권이 없습니다.\n하단의 '구독 시작하기' 버튼을 눌러 이용권을 구독해보세요.";
 
 const isCouponPassType = (passType?: string): boolean =>
   Boolean(passType && /coupon/i.test(passType));
@@ -207,7 +207,11 @@ const MembershipPage = () => {
       <Header name="계정 관리" pageName="Retrivr 프로" backTo="/account" />
 
       <div className="flex flex-1 flex-col overflow-y-auto no-scrollbar bg-gradient-to-b from-secondary-4 from-[14%] to-neutral-white to-[88%] font-[Pretendard]">
-        <section className="flex flex-col gap-3 px-12 pb-6 pt-10">
+        <section
+          className={`flex flex-col px-12 pb-6 pt-10 ${
+            showEmptyMembership ? "gap-5" : "gap-3"
+          }`}
+        >
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2">
               <h2 className="text-18px font-bold leading-normal text-neutral-gray-1">
@@ -215,21 +219,18 @@ const MembershipPage = () => {
               </h2>
               {hasActivePass ? <MembershipProBadge /> : null}
             </div>
-            <p className="text-12px font-bold leading-[1.5] text-secondary-2">
-              이용 방식:{" "}
-              {isMembershipLoading
-                ? "조회 중"
-                : showEmptyMembership
-                  ? EMPTY_USAGE_TYPE
-                  : (activePassTitle ?? "이용권")}
-            </p>
+            {isMembershipLoading ? null : showEmptyMembership ? (
+              <p className="whitespace-pre-line text-12px font-bold leading-[1.5] text-secondary-2">
+                {EMPTY_MEMBERSHIP_GUIDE}
+              </p>
+            ) : (
+              <p className="text-12px font-bold leading-[1.5] text-secondary-2">
+                이용 방식: {activePassTitle ?? "이용권"}
+              </p>
+            )}
           </div>
 
           <div className="flex flex-col gap-3">
-            {isMembershipLoading || showEmptyMembership ? (
-              <div className={VOUCHER_CARD_PLACEHOLDER_CLASS} aria-hidden />
-            ) : null}
-
             {hasActivePass && membership ? (
               <MembershipCouponCard
                 title={activePassTitle ?? "이용권"}

--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -8,11 +8,18 @@ import CouponSuccessModal from "../../components/modals/membership/CouponSuccess
 import MembershipCouponCard from "../../components/membership/MembershipCouponCard";
 import MembershipProBadge from "../../components/membership/MembershipProBadge";
 import {
+  useAdminMembership,
   useRegisterAdminCoupon,
   useRequestAdminCoupon,
 } from "../../hooks/queries/useAdminQueries";
-import type { AdminCouponLookupResponse } from "../../api/admin/admin.type";
-
+import type {
+  AdminCouponLookupResponse,
+  AdminMembershipResponse,
+} from "../../api/admin/admin.type";
+import {
+  formatCouponDay,
+  formatCouponValidityPeriod,
+} from "../../utils/couponDisplay";
 type BillingCycle = "monthly" | "yearly";
 type CouponAlertType =
   | "notFound"
@@ -20,12 +27,38 @@ type CouponAlertType =
   | "lookupFailed"
   | "registerFailed";
 
-const ACTIVE_PLAN = {
-  title: "월간 이용권",
-  priceAmount: "4,900₩",
-  priceUnit: "/월",
-  nextBillingDate: "26. 05. 01",
-  usageType: "월간 이용권",
+const EMPTY_USAGE_TYPE = "이용 중인 이용권이 없습니다.";
+const VOUCHER_CARD_PLACEHOLDER_CLASS = "min-h-[88px]";
+
+const isCouponPassType = (passType?: string): boolean =>
+  Boolean(passType && /coupon/i.test(passType));
+
+const resolveActivePassTitle = (
+  data: AdminMembershipResponse,
+): string | undefined => {
+  if (isCouponPassType(data.passType)) {
+    return data.couponInfo?.couponName?.trim() || undefined;
+  }
+  return (
+    data.subscriptionInfo?.subscriptionName?.trim() ||
+    data.couponInfo?.couponName?.trim() ||
+    undefined
+  );
+};
+
+const resolveActivePassFooter = (
+  data: AdminMembershipResponse,
+): string | undefined => {
+  if (isCouponPassType(data.passType) && data.startAt && data.endAt) {
+    return `사용 기간: ${formatCouponValidityPeriod(data.startAt, data.endAt)}`;
+  }
+  if (data.nextBillingAt) {
+    return `다음 결제 예정일: ${formatCouponDay(data.nextBillingAt)}`;
+  }
+  if (data.startAt && data.endAt) {
+    return `사용 기간: ${formatCouponValidityPeriod(data.startAt, data.endAt)}`;
+  }
+  return undefined;
 };
 
 const COUPON_ALERT_MESSAGES: Record<CouponAlertType, string> = {
@@ -73,11 +106,31 @@ const MembershipPage = () => {
 
   const lookupCouponMutation = useRequestAdminCoupon();
   const registerCouponMutation = useRegisterAdminCoupon();
+  const {
+    data: membership,
+    isLoading: isMembershipLoading,
+    isError: isMembershipError,
+    isSuccess: isMembershipSuccess,
+  } = useAdminMembership();
 
   const selectedPlan = SUBSCRIPTION_PLANS[billingCycle];
   const trimmedCouponCode = couponCode.trim();
   const canLookupCoupon =
     trimmedCouponCode.length > 0 && !lookupCouponMutation.isPending;
+
+  const activePassTitle = membership
+    ? resolveActivePassTitle(membership)
+    : undefined;
+  const hasActivePass =
+    isMembershipSuccess &&
+    Boolean(
+      activePassTitle ||
+        membership?.subscriptionInfo?.subscriptionName ||
+        membership?.couponInfo?.couponName ||
+        membership?.subscribed,
+    );
+  const showEmptyMembership =
+    !isMembershipLoading && (isMembershipError || !hasActivePass);
 
   const handleComingSoon = () => {
     alert(COMING_SOON_MESSAGE);
@@ -160,21 +213,35 @@ const MembershipPage = () => {
               <h2 className="text-18px font-bold leading-normal text-neutral-gray-1">
                 이용 현황
               </h2>
-              <MembershipProBadge />
+              {hasActivePass ? <MembershipProBadge /> : null}
             </div>
             <p className="text-12px font-bold leading-[1.5] text-secondary-2">
-              이용 방식: {ACTIVE_PLAN.usageType}
+              이용 방식:{" "}
+              {isMembershipLoading
+                ? "조회 중"
+                : showEmptyMembership
+                  ? EMPTY_USAGE_TYPE
+                  : (activePassTitle ?? "이용권")}
             </p>
           </div>
 
           <div className="flex flex-col gap-3">
-            <MembershipCouponCard
-              title={ACTIVE_PLAN.title}
-              status="active"
-              priceAmount={ACTIVE_PLAN.priceAmount}
-              priceUnit={ACTIVE_PLAN.priceUnit}
-              footerText={`다음 결제 예정일: ${ACTIVE_PLAN.nextBillingDate}`}
-            />
+            {isMembershipLoading || showEmptyMembership ? (
+              <div className={VOUCHER_CARD_PLACEHOLDER_CLASS} aria-hidden />
+            ) : null}
+
+            {hasActivePass && membership ? (
+              <MembershipCouponCard
+                title={activePassTitle ?? "이용권"}
+                status="active"
+                eventName={
+                  isCouponPassType(membership.passType)
+                    ? membership.couponInfo?.couponDescription
+                    : undefined
+                }
+                footerText={resolveActivePassFooter(membership)}
+              />
+            ) : null}
 
             <div className="flex flex-col gap-1.5">
               {MENU_ITEMS.map((item) => (

--- a/src/types/voucherList.ts
+++ b/src/types/voucherList.ts
@@ -19,16 +19,22 @@ export const HISTORY_PERIOD_LABEL: Record<HistoryPeriodOption, string> = {
   custom: "직접입력",
 };
 
-export const SUBSCRIPTION_VOUCHER = {
-  title: "연간 이용권",
-  statusLabel: "일시중지",
-  description:
-    "등록된 쿠폰 이용권을 모두 사용하면\n26.09.01부터 자동 결제가 다시 진행돼요.",
-  durationLabel: "12개월",
-  originalPrice: "58,800",
-  priceAmount: "46,900₩",
-  priceUnit: "/연",
-};
+export const COUPON_VOUCHERS = [
+  {
+    id: "coupon-active",
+    title: "2개월 이용권 쿠폰",
+    eventName: "Retrivr 출시 이벤트",
+    status: "active" as const,
+    footerText: "사용 기간: 26. 05. 01 ~ 26. 06. 30",
+  },
+  {
+    id: "coupon-pending",
+    title: "2개월 이용권 쿠폰",
+    eventName: "Retrivr 출시 이벤트",
+    status: "pending" as const,
+    footerText: "26. 07. 01 활성화 예정",
+  },
+];
 
 export const SUBSCRIPTION_USAGE_GUIDE = [
   "쿠폰 코드를 등록하면 쿠폰 이용권을 사용할 수 있습니다.",

--- a/src/types/voucherList.ts
+++ b/src/types/voucherList.ts
@@ -30,23 +30,6 @@ export const SUBSCRIPTION_VOUCHER = {
   priceUnit: "/연",
 };
 
-export const COUPON_VOUCHERS = [
-  {
-    id: "coupon-active",
-    title: "2개월 이용권 쿠폰",
-    eventName: "Retrivr 출시 이벤트",
-    status: "active" as const,
-    footerText: "사용 기간: 26. 05. 01 ~ 26. 06. 30",
-  },
-  {
-    id: "coupon-pending",
-    title: "2개월 이용권 쿠폰",
-    eventName: "Retrivr 출시 이벤트",
-    status: "pending" as const,
-    footerText: "26. 07. 01 활성화 예정",
-  },
-];
-
 export const SUBSCRIPTION_USAGE_GUIDE = [
   "쿠폰 코드를 등록하면 쿠폰 이용권을 사용할 수 있습니다.",
   "쿠폰 이용권은 등록 즉시 활성화됩니다.",


### PR DESCRIPTION
## 📌 Related Issues

- RTR-314

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- `GET /api/admin/v1/membership` 타입·API·`useAdminMembership` 훅 추가
- **구독 이용권**(`SubscriptionVoucherPanel`)에 연동
  - `subscriptionInfo.subscriptionName` → 제목
  - `passType`이 쿠폰이면 `일시중지`, 아니면 `이용중`
  - `nextBillingAt` → 일시중지/이용중 설명 문구
- 비정상 응답(비-200) / 구독 없음 → 중앙에 「현재 이용 중인 이용권이 없습니다.」
- 쿠폰 탭은 기존 목업으로 복원 (이번 티켓 범위 아님)

## ⭐ PR Point (To Reviewer)

- 가격·기간 목업 박스는 API에 대응 필드가 없어 제거했습니다.
- 400/404 등 오류도 빈 이용권 문구로 통일한 것은 요청된 UX입니다.
- 쿠폰 탭 목업 복원은 의도된 범위입니다.

## 📷 Screenshot

<!-- 생략 -->

## 🔔 ETC