### PR TITLE
[RTR-317] 관리자 프로필 조회 응답을 organizationName만 받도록 변경

### DIFF
--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -153,11 +153,10 @@ export const WITHDRAW_ERROR_CODE = {
 } as const;
 
 // 6. 관리자 프로필 조회
+// 엔드포인트: "/api/admin/v1/profile" (GET)
+// 응답은 organizationName만 반환한다.
 export interface AdminProfileResponse {
-  organizationId: number; // 관리자 고유 번호
   organizationName: string; // 관리자 이름 (단체명)
-  profileImageUrl?: string; // 프로필 사진 URL
-  email: string; // 관리자 이메일
 }
 
 // 6-1. 관리자 이메일 인증 코드 발송

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -9,6 +9,7 @@ import LogoutConfirmModal from "../../components/modals/admin/account/LogoutConf
 import QRCodeDisplay from "../../components/qr/QRCodeDisplay";
 import { useAdminProfile, useLogout } from "../../hooks/queries/useAuthQueries";
 import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
+import { getAdminEmail } from "../../utils/adminSession";
 
 const PRODUCTION_WEB_ORIGIN = "https://www.retrivr.kr";
 const PREVIEW_WEB_ORIGIN = "https://retrivr-web.vercel.app";
@@ -26,6 +27,7 @@ const clearAdminSession = () => {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
   localStorage.removeItem("orgId");
+  localStorage.removeItem("email");
   resetPaymentMethodsStore();
 };
 
@@ -45,12 +47,14 @@ const AccountPage = () => {
     typeof window === "undefined"
       ? null
       : Number(localStorage.getItem("orgId") ?? "");
+  const storedEmail = getAdminEmail();
 
   const userProfile = {
-    organizationId: data?.organizationId,
+    organizationId,
     organizationName: data?.organizationName,
-    profileImageUrl: data?.profileImageUrl ?? "/icons/profile-default-icon.svg",
-    email: data?.email,
+    // 프로필 API에서 profileImageUrl이 제거되어 기본 아이콘을 사용한다
+    profileImageUrl: "/icons/profile-default-icon.svg",
+    email: storedEmail,
   };
 
   const rentalPageUrl = useMemo(() => {
@@ -59,7 +63,7 @@ const AccountPage = () => {
       return `${publicWebOrigin}/client-search`;
     }
     return `${publicWebOrigin}/client-home?organizationId=${encodeURIComponent(
-      String(userProfile.organizationId),
+      String(organizationId),
     )}`;
   }, [organizationId]);
 

--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -46,6 +46,9 @@ const LoginPage = () => {
           if (organizationId != null) {
             localStorage.setItem("orgId", String(organizationId));
           }
+          // 프로필 API에서 email이 제거되어 로그인 이메일을 저장해 계정 화면에 사용한다
+          // 응답 email이 빈 문자열일 수 있어 폼 입력을 우선 폴백한다
+          localStorage.setItem("email", (data.email || email).trim());
           navigate("/home");
         },
         onError: () => {

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -22,6 +22,7 @@ import {
   useUpdateAdminProfile,
 } from "../../hooks/queries/useAuthQueries";
 import type { UpdateAdminProfileErrorResponse } from "../../api/auth/auth.type";
+import { getAdminEmail } from "../../utils/adminSession";
 
 type ChangeTarget = "email" | "password" | "adminCode";
 
@@ -51,11 +52,15 @@ const ProfileEditPage = () => {
   const hasHydratedProfileRef = useRef(false);
 
   useEffect(() => {
+    // 이메일은 프로필 API에 없으므로 마운트 시 세션에서 바로 채운다
+    setEmail(getAdminEmail());
+  }, []);
+
+  useEffect(() => {
     if (!profile || hasHydratedProfileRef.current) return;
     const name = profile.organizationName ?? "";
     setOrganizationName(name);
     setSavedOrganizationName(name);
-    setEmail(profile.email ?? "");
     hasHydratedProfileRef.current = true;
   }, [profile]);
 
@@ -307,7 +312,7 @@ const ProfileEditPage = () => {
       <IdentityVerificationBottomSheet
         ref={identitySheetRef}
         isOpen={isIdentitySheetOpen}
-        email={email || profile?.email || ""}
+        email={email || getAdminEmail()}
         onClose={() => {
           setIsIdentitySheetOpen(false);
           setPendingChangeTarget(null);
@@ -321,6 +326,7 @@ const ProfileEditPage = () => {
         onClose={() => setIsEmailSheetOpen(false)}
         onChanged={(nextEmail) => {
           setEmail(nextEmail);
+          localStorage.setItem("email", nextEmail);
           showCompleteModal();
         }}
       />

--- a/src/pages/admin/WithdrawPage.tsx
+++ b/src/pages/admin/WithdrawPage.tsx
@@ -10,7 +10,6 @@ import WithdrawExitConfirmModal from "../../components/modals/admin/account/With
 import WithdrawPasswordMismatchModal from "../../components/modals/admin/account/WithdrawPasswordMismatchModal";
 import WithdrawCompleteModal from "../../components/modals/admin/account/WithdrawCompleteModal";
 import {
-  useAdminProfile,
   useWithdraw,
 } from "../../hooks/queries/useAuthQueries";
 import type {
@@ -19,6 +18,7 @@ import type {
 } from "../../api/auth/auth.type";
 import { WITHDRAW_ERROR_CODE } from "../../api/auth/auth.type";
 import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
+import { getAdminEmail } from "../../utils/adminSession";
 
 const NOTICE_ITEMS = [
   {
@@ -59,11 +59,9 @@ const clearAdminSession = () => {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
   localStorage.removeItem("orgId");
+  localStorage.removeItem("email");
   resetPaymentMethodsStore();
 };
-
-const hasAccessToken = () =>
-  typeof window !== "undefined" && Boolean(localStorage.getItem("accessToken"));
 
 const StepIndicator = ({ step }: { step: WithdrawStep }) => {
   const circle = (n: WithdrawStep) => {
@@ -100,10 +98,6 @@ const WithdrawPage = () => {
   const [isWithdrawComplete, setIsWithdrawComplete] = useState(false);
   /** onError 등 비동기 콜백에서 최신 탈퇴 완료 여부를 읽기 위한 ref */
   const isWithdrawCompleteRef = useRef(false);
-  // 세션이 없거나 탈퇴 완료 후에는 프로필 API를 호출하지 않는다
-  const { data: profile } = useAdminProfile({
-    enabled: hasAccessToken() && !isWithdrawComplete,
-  });
   const { mutate: withdraw, isPending: isWithdrawing } = useWithdraw();
 
   const [step, setStep] = useState<WithdrawStep>(1);
@@ -129,7 +123,7 @@ const WithdrawPage = () => {
   const [isPasswordMismatchOpen, setIsPasswordMismatchOpen] = useState(false);
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
 
-  const email = profile?.email ?? "";
+  const email = getAdminEmail();
 
   const canGoNext = useMemo(() => {
     if (!agreedToWarning || selectedReasons.size === 0) return false;

--- a/src/utils/adminSession.ts
+++ b/src/utils/adminSession.ts
@@ -1,0 +1,39 @@
+/** 관리자 세션에 저장된 이메일을 반환한다. 없으면 JWT payload에서 복구를 시도한다. */
+export const getAdminEmail = (): string => {
+  if (typeof window === "undefined") return "";
+
+  const stored = localStorage.getItem("email")?.trim();
+  if (stored) return stored;
+
+  const token = localStorage.getItem("accessToken");
+  if (!token) return "";
+
+  try {
+    const payloadPart = token.split(".")[1];
+    if (!payloadPart) return "";
+
+    const normalized = payloadPart.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "=",
+    );
+    const payload = JSON.parse(atob(padded)) as {
+      email?: unknown;
+      sub?: unknown;
+    };
+
+    const fromEmail =
+      typeof payload.email === "string" ? payload.email.trim() : "";
+    const fromSub =
+      typeof payload.sub === "string" && payload.sub.includes("@")
+        ? payload.sub.trim()
+        : "";
+    const recovered = fromEmail || fromSub;
+    if (!recovered) return "";
+
+    localStorage.setItem("email", recovered);
+    return recovered;
+  } catch {
+    return "";
+  }
+};


### PR DESCRIPTION
## 📌 Related Issues

- RTR-317

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요?
- [x] 빌드가 성공했나요? (tsc)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- GET `/api/admin/v1/profile` 응답 타입에서 `organizationId`, `email`, `profileImageUrl` 제거
- `organizationName`만 사용하도록 타입/소비처 정리
- 로그인 시 email을 localStorage에 저장하고, 기존 세션은 JWT에서 복구 (`getAdminEmail`)

## ⭐ PR Point (To Reviewer)

- 계정/프로필/탈퇴 화면의 email 표시가 프로필 API가 아닌 세션 저장값에 의존합니다.

## 🔔 ETC

- Bugbot: medium 4건 수정 후 clean
- Swagger: http://ec2-3-38-98-81.ap-northeast-2.compute.amazonaws.com/swagger-ui/index.html


Made with [Cursor](https://cursor.com)