### PR TITLE
[RTR-319] 관리자 이메일 인증 발송 API를 passwordVerificationToken 기반으로 변경

### DIFF
--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -161,10 +161,15 @@ export interface AdminProfileResponse {
 
 // 6-1. 관리자 이메일 인증 코드 발송
 // 엔드포인트: "/api/admin/v1/email/verification" (POST)
-// 요청/응답 바디는 public 이메일 인증과 동일 형태 (purpose: EMAIL_CHANGE)
+export interface SendAdminEmailCodeRequest {
+  email: string;
+  passwordVerificationToken: string; // EMAIL_CHANGE 목적 비밀번호 인증 토큰
+}
 
-export type SendAdminEmailCodeRequest = SendEmailCodeRequest;
-export type SendAdminEmailCodeResponse = SendEmailCodeResponse;
+export interface SendAdminEmailCodeResponse {
+  expiresInSeconds: number;
+  resendAvailableInSeconds: number;
+}
 
 // 6-2. 관리자 이메일 인증 코드 검증
 // 엔드포인트: "/api/admin/v1/email/verification/verify" (POST)

--- a/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
@@ -28,6 +28,8 @@ type EmailChangeBottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
   onChanged: (email: string) => void;
+  /** EMAIL_CHANGE 목적 비밀번호 인증 토큰 (RTR-321에서 발급) */
+  passwordVerificationToken: string;
 };
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -43,7 +45,7 @@ const formatTime = (seconds: number) => {
 const EmailChangeBottomSheet = forwardRef<
   EmailChangeBottomSheetHandle,
   EmailChangeBottomSheetProps
->(({ isOpen, onClose, onChanged }, ref) => {
+>(({ isOpen, onClose, onChanged, passwordVerificationToken }, ref) => {
   const [newEmail, setNewEmail] = useState("");
   const [authCode, setAuthCode] = useState("");
   const [timeLeft, setTimeLeft] = useState(0);
@@ -114,6 +116,7 @@ const EmailChangeBottomSheet = forwardRef<
   const canSendCode =
     trimmedEmail.length > 0 &&
     isEmailFormatValid &&
+    Boolean(passwordVerificationToken) &&
     !isTimerActive &&
     !isSendingCode;
   const canVerifyCode =
@@ -132,6 +135,10 @@ const EmailChangeBottomSheet = forwardRef<
       setEmailFormatError(true);
       return;
     }
+    if (!passwordVerificationToken) {
+      alert("본인 확인이 필요합니다. 다시 시도해주세요.");
+      return;
+    }
 
     const requestId = ++sendRequestIdRef.current;
     verifyRequestIdRef.current += 1;
@@ -139,7 +146,10 @@ const EmailChangeBottomSheet = forwardRef<
     setCodeMismatchError(false);
 
     sendCode(
-      { email: trimmedEmail, purpose: "EMAIL_CHANGE" },
+      {
+        email: trimmedEmail,
+        passwordVerificationToken,
+      },
       {
         onSuccess: (data) => {
           if (requestId !== sendRequestIdRef.current) return;

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -43,6 +43,8 @@ const ProfileEditPage = () => {
   const [email, setEmail] = useState("");
   const [pendingChangeTarget, setPendingChangeTarget] =
     useState<ChangeTarget | null>(null);
+  const [passwordVerificationToken, setPasswordVerificationToken] =
+    useState("");
   const [isIdentitySheetOpen, setIsIdentitySheetOpen] = useState(false);
   const [isEmailSheetOpen, setIsEmailSheetOpen] = useState(false);
   const [isPasswordSheetOpen, setIsPasswordSheetOpen] = useState(false);
@@ -90,6 +92,7 @@ const ProfileEditPage = () => {
 
   const openIdentitySheet = (target: ChangeTarget) => {
     setPendingChangeTarget(target);
+    setPasswordVerificationToken("");
     setIsIdentitySheetOpen(true);
   };
 
@@ -325,10 +328,15 @@ const ProfileEditPage = () => {
       <EmailChangeBottomSheet
         ref={emailSheetRef}
         isOpen={isEmailSheetOpen}
-        onClose={() => setIsEmailSheetOpen(false)}
+        passwordVerificationToken={passwordVerificationToken}
+        onClose={() => {
+          setIsEmailSheetOpen(false);
+          setPasswordVerificationToken("");
+        }}
         onChanged={(nextEmail) => {
           setEmail(nextEmail);
           localStorage.setItem("email", nextEmail);
+          setPasswordVerificationToken("");
           showCompleteModal();
         }}
       />


### PR DESCRIPTION
## 📌 Related Issues

- RTR-319

## 📄 Tasks

- POST `/api/admin/v1/email/verification` 요청에서 `purpose` 제거, `passwordVerificationToken` 추가
- 응답에서 `email`/`purpose` 제거, `expiresInSeconds`/`resendAvailableInSeconds`만 사용
- EmailChangeBottomSheet에 토큰 prop 연동 (토큰 발급은 RTR-321)

## 🔔 ETC

- Bugbot: clean
- Swagger: http://ec2-3-38-98-81.ap-northeast-2.compute.amazonaws.com/swagger-ui/index.html


Made with [Cursor](https://cursor.com)