### PR TITLE
[RTR-320] 관리자 이메일 인증 검증을 204·로그아웃으로 변경

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -16,7 +16,6 @@ import type {
   SendAdminEmailCodeRequest,
   SendAdminEmailCodeResponse,
   VerifyAdminEmailCodeRequest,
-  VerifyAdminEmailCodeResponse,
   UpdateAdminProfileRequest,
   LoadHomeResponse,
   LogoutResponse,
@@ -168,16 +167,13 @@ export const sendAdminEmailCode = async (
 };
 
 //
-// 7-2. 관리자 이메일 인증 코드 검증 API (POST)
+// 7-2. 관리자 이메일 인증 코드 검증 및 이메일 변경 API (POST)
 // 엔드포인트 : "/api/admin/v1/email/verification/verify"
+// 성공 시 204 No Content (세션 만료)
 export const verifyAdminEmailCode = async (
   data: VerifyAdminEmailCodeRequest,
-): Promise<VerifyAdminEmailCodeResponse> => {
-  const response = await apiClient.post<VerifyAdminEmailCodeResponse>(
-    "/api/admin/v1/email/verification/verify",
-    data,
-  );
-  return response.data;
+): Promise<void> => {
+  await apiClient.post("/api/admin/v1/email/verification/verify", data);
 };
 
 //

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -171,18 +171,13 @@ export interface SendAdminEmailCodeResponse {
   resendAvailableInSeconds: number;
 }
 
-// 6-2. 관리자 이메일 인증 코드 검증
+// 6-2. 관리자 이메일 인증 코드 검증 및 이메일 변경
 // 엔드포인트: "/api/admin/v1/email/verification/verify" (POST)
+// 성공 시 204 No Content (세션 만료)
 export interface VerifyAdminEmailCodeRequest {
   email: string;
-  purpose: EmailVerificationPurpose; // 이메일 변경: EMAIL_CHANGE
   code: string;
-}
-
-export interface VerifyAdminEmailCodeResponse {
-  tokenType: string;
-  token: string;
-  expiresInSeconds: number;
+  passwordVerificationToken: string; // EMAIL_CHANGE 목적 비밀번호 인증 토큰
 }
 
 // 관리자 이메일 인증 공통 에러 응답 (400/429 등)

--- a/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/EmailChangeBottomSheet.tsx
@@ -12,13 +12,12 @@ import Button from "../../../Button";
 import ProfileChangeExitConfirmModal from "./ProfileChangeExitConfirmModal";
 import {
   useSendAdminEmailCode,
-  useUpdateAdminProfile,
   useVerifyAdminEmailCode,
 } from "../../../../hooks/queries/useAuthQueries";
 import type {
   AdminEmailVerificationErrorResponse,
-  UpdateAdminProfileErrorResponse,
 } from "../../../../api/auth/auth.type";
+import { ADMIN_EMAIL_VERIFICATION_ERROR_CODE } from "../../../../api/auth/auth.type";
 
 export type EmailChangeBottomSheetHandle = {
   requestClose: () => void;
@@ -27,6 +26,7 @@ export type EmailChangeBottomSheetHandle = {
 type EmailChangeBottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
+  /** 이메일 변경(검증) 성공 후 호출. 호출측에서 로그아웃 처리한다. */
   onChanged: (email: string) => void;
   /** EMAIL_CHANGE 목적 비밀번호 인증 토큰 (RTR-321에서 발급) */
   passwordVerificationToken: string;
@@ -53,17 +53,13 @@ const EmailChangeBottomSheet = forwardRef<
   const [hasRequestedCode, setHasRequestedCode] = useState(false);
   const [emailFormatError, setEmailFormatError] = useState(false);
   const [codeMismatchError, setCodeMismatchError] = useState(false);
-  const [verificationToken, setVerificationToken] = useState("");
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
   const sendRequestIdRef = useRef(0);
   const verifyRequestIdRef = useRef(0);
-  const updateRequestIdRef = useRef(0);
 
   const { mutate: sendCode, isPending: isSendingCode } = useSendAdminEmailCode();
   const { mutate: verifyCode, isPending: isVerifyingCode } =
     useVerifyAdminEmailCode();
-  const { mutate: updateProfile, isPending: isUpdating } =
-    useUpdateAdminProfile();
 
   const handleRequestClose = () => {
     setIsExitModalOpen(true);
@@ -77,7 +73,6 @@ const EmailChangeBottomSheet = forwardRef<
     if (!isOpen) {
       sendRequestIdRef.current += 1;
       verifyRequestIdRef.current += 1;
-      updateRequestIdRef.current += 1;
       setNewEmail("");
       setAuthCode("");
       setTimeLeft(0);
@@ -85,7 +80,6 @@ const EmailChangeBottomSheet = forwardRef<
       setHasRequestedCode(false);
       setEmailFormatError(false);
       setCodeMismatchError(false);
-      setVerificationToken("");
       setIsExitModalOpen(false);
     }
   }, [isOpen]);
@@ -106,7 +100,6 @@ const EmailChangeBottomSheet = forwardRef<
   const handleConfirmExit = () => {
     sendRequestIdRef.current += 1;
     verifyRequestIdRef.current += 1;
-    updateRequestIdRef.current += 1;
     setIsExitModalOpen(false);
     onClose();
   };
@@ -123,11 +116,9 @@ const EmailChangeBottomSheet = forwardRef<
     isTimerActive &&
     timeLeft > 0 &&
     authCode.trim().length > 0 &&
+    Boolean(passwordVerificationToken) &&
     !codeMismatchError &&
-    !isVerifyingCode &&
-    !verificationToken;
-  const canChange =
-    Boolean(verificationToken) && trimmedEmail.length > 0 && !isUpdating;
+    !isVerifyingCode;
 
   const handleSendCode = () => {
     if (!trimmedEmail) return;
@@ -142,7 +133,6 @@ const EmailChangeBottomSheet = forwardRef<
 
     const requestId = ++sendRequestIdRef.current;
     verifyRequestIdRef.current += 1;
-    setVerificationToken("");
     setCodeMismatchError(false);
 
     sendCode(
@@ -177,58 +167,49 @@ const EmailChangeBottomSheet = forwardRef<
 
   const handleVerifyCode = () => {
     const code = authCode.trim();
-    if (!code || !trimmedEmail) return;
+    if (!code || !trimmedEmail || !passwordVerificationToken) return;
 
     const requestId = ++verifyRequestIdRef.current;
 
+    // 검증 성공 시 이메일이 변경되고 세션이 만료되므로 호출측에서 로그아웃한다
     verifyCode(
-      { email: trimmedEmail, purpose: "EMAIL_CHANGE", code },
       {
-        onSuccess: (data) => {
-          if (requestId !== verifyRequestIdRef.current) return;
-          if (!data.token) {
-            alert("인증 토큰 발급에 실패했습니다. 다시 시도해주세요.");
-            return;
-          }
-          setIsTimerActive(false);
-          setCodeMismatchError(false);
-          setVerificationToken(data.token);
-        },
-        onError: () => {
-          if (requestId !== verifyRequestIdRef.current) return;
-          setCodeMismatchError(true);
-        },
+        email: trimmedEmail,
+        code,
+        passwordVerificationToken,
       },
-    );
-  };
-
-  const handleChangeEmail = () => {
-    if (!canChange) return;
-
-    const requestId = ++updateRequestIdRef.current;
-
-    // RTR-319/320에서 이메일 전용 API로 교체 예정 (현재 PATCH /profile은 organizationName만 허용)
-    updateProfile(
-      {
-        newEmail: trimmedEmail,
-        adminCodeVerificationToken: verificationToken,
-      } as unknown as Parameters<typeof updateProfile>[0],
       {
         onSuccess: () => {
-          if (requestId !== updateRequestIdRef.current) return;
+          // 세션을 만료시키는 성공은 시트 닫힘/취소와 무관하게 반드시 로그아웃한다
+          setIsTimerActive(false);
+          setCodeMismatchError(false);
           onChanged(trimmedEmail);
           onClose();
         },
         onError: (error) => {
-          if (requestId !== updateRequestIdRef.current) return;
+          if (requestId !== verifyRequestIdRef.current) return;
           if (axios.isAxiosError(error)) {
             const data = error.response?.data as
-              | UpdateAdminProfileErrorResponse
+              | AdminEmailVerificationErrorResponse
               | undefined;
-            if (data?.message) {
-              alert(data.message);
+            const code = data?.code;
+            const isKnownNonMismatch =
+              code ===
+                ADMIN_EMAIL_VERIFICATION_ERROR_CODE.REQUEST_NOT_FOUND ||
+              code ===
+                ADMIN_EMAIL_VERIFICATION_ERROR_CODE.TOO_MANY_REQUESTS;
+
+            if (isKnownNonMismatch || error.response?.status !== 400) {
+              alert(
+                data?.message ??
+                  "이메일 변경에 실패했습니다. 다시 시도해주세요.",
+              );
               return;
             }
+
+            // 400 중 인증번호 불일치로 취급
+            setCodeMismatchError(true);
+            return;
           }
           alert("이메일 변경에 실패했습니다. 다시 시도해주세요.");
         },
@@ -242,7 +223,7 @@ const EmailChangeBottomSheet = forwardRef<
         isOpen={isOpen}
         onClose={handleRequestClose}
         title="이메일 변경"
-        description="변경 시 이메일 인증이 필요해요"
+        description="변경 시 이메일 인증이 필요해요. 변경 후 다시 로그인해야 합니다."
         sheetClassName="h-[612px] max-h-full"
         footer={
           <Button
@@ -250,10 +231,10 @@ const EmailChangeBottomSheet = forwardRef<
             variant="primary"
             size="lg"
             className="h-12.5 w-full max-w-none rounded-[23.164px] shadow-primary text-18px"
-            disabled={!canChange}
-            onClick={handleChangeEmail}
+            disabled={!canVerifyCode}
+            onClick={handleVerifyCode}
           >
-            {isUpdating ? "변경 중..." : "변경하기"}
+            {isVerifyingCode ? "변경 중..." : "변경하기"}
           </Button>
         }
       >
@@ -268,7 +249,6 @@ const EmailChangeBottomSheet = forwardRef<
                 onChange={(event) => {
                   setNewEmail(event.target.value);
                   setEmailFormatError(false);
-                  setVerificationToken("");
                 }}
                 onBlur={() => {
                   if (trimmedEmail && !isEmailFormatValid) {
@@ -314,7 +294,7 @@ const EmailChangeBottomSheet = forwardRef<
                   setCodeMismatchError(false);
                 }}
                 placeholder="인증번호 입력"
-                disabled={!isTimerActive && !verificationToken}
+                disabled={!isTimerActive}
                 className="h-12 max-w-none rounded-xl px-3.5 pr-14 placeholder:text-14px placeholder:font-normal placeholder:leading-[140%] placeholder:text-neutral-gray-3"
               />
               {isTimerActive && timeLeft > 0 ? (

--- a/src/pages/admin/AccountPage.tsx
+++ b/src/pages/admin/AccountPage.tsx
@@ -8,8 +8,7 @@ import ConfirmModal from "../../components/modals/ConfirmModal";
 import LogoutConfirmModal from "../../components/modals/admin/account/LogoutConfirmModal";
 import QRCodeDisplay from "../../components/qr/QRCodeDisplay";
 import { useAdminProfile, useLogout } from "../../hooks/queries/useAuthQueries";
-import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
-import { getAdminEmail } from "../../utils/adminSession";
+import { clearAdminSession, getAdminEmail } from "../../utils/adminSession";
 
 const PRODUCTION_WEB_ORIGIN = "https://www.retrivr.kr";
 const PREVIEW_WEB_ORIGIN = "https://retrivr-web.vercel.app";
@@ -21,14 +20,6 @@ const getPublicWebOrigin = () => {
     return PRODUCTION_WEB_ORIGIN;
   }
   return PREVIEW_WEB_ORIGIN;
-};
-
-const clearAdminSession = () => {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
-  localStorage.removeItem("orgId");
-  localStorage.removeItem("email");
-  resetPaymentMethodsStore();
 };
 
 const AccountPage = () => {

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
+import { useQueryClient } from "@tanstack/react-query";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import CommonInput from "../../components/CommonInput";
@@ -22,13 +24,15 @@ import {
   useUpdateAdminProfile,
 } from "../../hooks/queries/useAuthQueries";
 import type { UpdateAdminProfileErrorResponse } from "../../api/auth/auth.type";
-import { getAdminEmail } from "../../utils/adminSession";
+import { getAdminEmail, clearAdminSession } from "../../utils/adminSession";
 
 type ChangeTarget = "email" | "password" | "adminCode";
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
-  const { data: profile } = useAdminProfile();
+  const queryClient = useQueryClient();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const { data: profile } = useAdminProfile({ enabled: !isSigningOut });
   const { mutate: updateProfile, isPending: isUpdatingName } =
     useUpdateAdminProfile();
 
@@ -333,11 +337,20 @@ const ProfileEditPage = () => {
           setIsEmailSheetOpen(false);
           setPasswordVerificationToken("");
         }}
-        onChanged={(nextEmail) => {
-          setEmail(nextEmail);
-          localStorage.setItem("email", nextEmail);
+        onChanged={async () => {
+          // enabled=false가 clear() 전에 반영되도록 동기적으로 반영
+          flushSync(() => {
+            setIsSigningOut(true);
+          });
+          setIsEmailSheetOpen(false);
           setPasswordVerificationToken("");
-          showCompleteModal();
+          clearAdminSession();
+          await queryClient.cancelQueries();
+          alert("이메일이 변경되었습니다. 다시 로그인해주세요.");
+          navigate("/login", { replace: true });
+          queueMicrotask(() => {
+            queryClient.clear();
+          });
         }}
       />
 

--- a/src/pages/admin/WithdrawPage.tsx
+++ b/src/pages/admin/WithdrawPage.tsx
@@ -17,8 +17,7 @@ import type {
   WithdrawReasonCode,
 } from "../../api/auth/auth.type";
 import { WITHDRAW_ERROR_CODE } from "../../api/auth/auth.type";
-import { resetPaymentMethodsStore } from "../../store/paymentMethodsStore";
-import { getAdminEmail } from "../../utils/adminSession";
+import { clearAdminSession, getAdminEmail } from "../../utils/adminSession";
 
 const NOTICE_ITEMS = [
   {
@@ -54,14 +53,6 @@ const WITHDRAW_REASONS: { code: WithdrawReasonCode; label: string }[] = [
 
 type WithdrawStep = 1 | 2;
 type SlideDirection = "forward" | "back";
-
-const clearAdminSession = () => {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
-  localStorage.removeItem("orgId");
-  localStorage.removeItem("email");
-  resetPaymentMethodsStore();
-};
 
 const StepIndicator = ({ step }: { step: WithdrawStep }) => {
   const circle = (n: WithdrawStep) => {

--- a/src/utils/adminSession.ts
+++ b/src/utils/adminSession.ts
@@ -1,3 +1,5 @@
+import { resetPaymentMethodsStore } from "../store/paymentMethodsStore";
+
 /** 관리자 세션에 저장된 이메일을 반환한다. 없으면 JWT payload에서 복구를 시도한다. */
 export const getAdminEmail = (): string => {
   if (typeof window === "undefined") return "";
@@ -36,4 +38,13 @@ export const getAdminEmail = (): string => {
   } catch {
     return "";
   }
+};
+
+/** 관리자 클라이언트 세션(토큰·식별자·결제수단 스토어)을 정리한다. */
+export const clearAdminSession = () => {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("orgId");
+  localStorage.removeItem("email");
+  resetPaymentMethodsStore();
 };


### PR DESCRIPTION
## 📌 Related Issues

- RTR-320

## 📄 Tasks

- POST `/api/admin/v1/email/verification/verify`에서 purpose 제거, passwordVerificationToken 추가
- 성공 시 204 No Content
- 성공 시 클라이언트 세션 정리 후 로그인으로 이동

## 🔔 ETC

- Bugbot: medium 다수 수정 후 clean
- Swagger: http://ec2-3-38-98-81.ap-northeast-2.compute.amazonaws.com/swagger-ui/index.html


Made with [Cursor](https://cursor.com)