### PR TITLE
[RTR-321] 개인정보 변경용 비밀번호 확인 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -17,6 +17,8 @@ import type {
   SendAdminEmailCodeResponse,
   VerifyAdminEmailCodeRequest,
   UpdateAdminProfileRequest,
+  VerifyAdminPasswordRequest,
+  VerifyAdminPasswordResponse,
   LoadHomeResponse,
   LogoutResponse,
   WithdrawRequest,
@@ -184,4 +186,17 @@ export const updateAdminProfile = async (
   data: UpdateAdminProfileRequest,
 ): Promise<void> => {
   await apiClient.patch("/api/admin/v1/profile", data);
+};
+
+//
+// 7-4. 개인정보 변경용 현재 비밀번호 확인 API (POST)
+// 엔드포인트 : "/api/admin/v1/profile/password/verify"
+export const verifyAdminPassword = async (
+  data: VerifyAdminPasswordRequest,
+): Promise<VerifyAdminPasswordResponse> => {
+  const response = await apiClient.post<VerifyAdminPasswordResponse>(
+    "/api/admin/v1/profile/password/verify",
+    data,
+  );
+  return response.data;
 };

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -213,6 +213,30 @@ export const UPDATE_ADMIN_PROFILE_ERROR_CODE = {
   ORGANIZATION_NOT_FOUND: 3004, // 404: 존재하지 않는 단체입니다.
 } as const;
 
+// 6-4. 개인정보 변경용 현재 비밀번호 확인
+// 엔드포인트: "/api/admin/v1/profile/password/verify" (POST)
+export type AdminPasswordVerificationPurpose =
+  | "EMAIL_CHANGE"
+  | "PASSWORD_CHANGE"
+  | "ADMIN_CODE_CHANGE";
+
+export interface VerifyAdminPasswordRequest {
+  password: string;
+  purpose: AdminPasswordVerificationPurpose;
+}
+
+export interface VerifyAdminPasswordResponse {
+  verificationToken: string;
+  expiresIn: number; // 토큰 유효 시간(초)
+}
+
+export interface VerifyAdminPasswordErrorResponse {
+  status: string;
+  code: number;
+  message: string;
+  detail?: string;
+}
+
 // 7. 홈 화면 출력 요청
 // 홈 화면 출력 요청 바디 없음
 

--- a/src/components/modals/admin/account/IdentityVerificationBottomSheet.tsx
+++ b/src/components/modals/admin/account/IdentityVerificationBottomSheet.tsx
@@ -5,11 +5,16 @@ import {
   useRef,
   useState,
 } from "react";
+import axios from "axios";
 import BottomSheet from "../../../BottomSheet";
 import CommonInput from "../../../CommonInput";
 import Button from "../../../Button";
 import ProfileChangeExitConfirmModal from "./ProfileChangeExitConfirmModal";
-import { useLogin } from "../../../../hooks/queries/useAuthQueries";
+import { useVerifyAdminPassword } from "../../../../hooks/queries/useAuthQueries";
+import type {
+  AdminPasswordVerificationPurpose,
+  VerifyAdminPasswordErrorResponse,
+} from "../../../../api/auth/auth.type";
 
 export type IdentityVerificationBottomSheetHandle = {
   requestClose: () => void;
@@ -17,20 +22,20 @@ export type IdentityVerificationBottomSheetHandle = {
 
 type IdentityVerificationBottomSheetProps = {
   isOpen: boolean;
-  email: string;
+  purpose: AdminPasswordVerificationPurpose;
   onClose: () => void;
-  onVerified: () => void;
+  onVerified: (verificationToken: string, expiresIn: number) => void;
 };
 
 const IdentityVerificationBottomSheet = forwardRef<
   IdentityVerificationBottomSheetHandle,
   IdentityVerificationBottomSheetProps
->(({ isOpen, email, onClose, onVerified }, ref) => {
+>(({ isOpen, purpose, onClose, onVerified }, ref) => {
   const [password, setPassword] = useState("");
   const [isMismatch, setIsMismatch] = useState(false);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
   const verifyRequestIdRef = useRef(0);
-  const { mutate: login, isPending } = useLogin();
+  const { mutate: verifyPassword, isPending } = useVerifyAdminPassword();
 
   const handleRequestClose = () => {
     setIsExitModalOpen(true);
@@ -57,27 +62,47 @@ const IdentityVerificationBottomSheet = forwardRef<
 
   const handleVerify = () => {
     const trimmed = password.trim();
-    if (!trimmed || !email || isPending) return;
+    if (!trimmed || isPending) return;
 
     const requestId = ++verifyRequestIdRef.current;
 
-    login(
-      { email, password: trimmed },
+    verifyPassword(
+      { password: trimmed, purpose },
       {
         onSuccess: (data) => {
           if (requestId !== verifyRequestIdRef.current) return;
-          if (data.accessToken) {
-            localStorage.setItem("accessToken", data.accessToken);
-          }
-          if (data.refreshToken) {
-            localStorage.setItem("refreshToken", data.refreshToken);
+          if (!data.verificationToken) {
+            alert("본인 확인에 실패했습니다. 다시 시도해주세요.");
+            return;
           }
           setIsMismatch(false);
-          onVerified();
+          onVerified(data.verificationToken, data.expiresIn);
         },
-        onError: () => {
+        onError: (error) => {
           if (requestId !== verifyRequestIdRef.current) return;
-          setIsMismatch(true);
+          if (axios.isAxiosError(error)) {
+            const status = error.response?.status;
+            const data = error.response?.data as
+              | VerifyAdminPasswordErrorResponse
+              | undefined;
+            if (status === 400) {
+              setIsMismatch(true);
+              return;
+            }
+            if (status === 401 || status === 403) {
+              alert(
+                data?.message ??
+                  "세션이 만료되었습니다. 다시 로그인한 뒤 시도해주세요.",
+              );
+              return;
+            }
+            alert(
+              data?.message ??
+                "본인 확인에 실패했습니다. 다시 시도해주세요.",
+            );
+            return;
+          }
+          alert("본인 확인에 실패했습니다. 다시 시도해주세요.");
         },
       },
     );

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -13,6 +13,7 @@ import {
   sendAdminEmailCode,
   verifyAdminEmailCode,
   updateAdminProfile,
+  verifyAdminPassword,
 } from "../../api/auth/auth.api";
 
 //
@@ -214,6 +215,21 @@ export const useUpdateAdminProfile = () => {
     },
     onError: (error) => {
       console.error("관리자 프로필 수정 실패:", error);
+    },
+  });
+};
+
+//
+// 7-4. 개인정보 변경용 현재 비밀번호 확인 요청
+//
+export const useVerifyAdminPassword = () => {
+  return useMutation({
+    mutationFn: verifyAdminPassword,
+    onSuccess: () => {
+      console.log("관리자 비밀번호 확인 성공");
+    },
+    onError: (error) => {
+      console.error("관리자 비밀번호 확인 실패:", error);
     },
   });
 };

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -23,10 +23,22 @@ import {
   useAdminProfile,
   useUpdateAdminProfile,
 } from "../../hooks/queries/useAuthQueries";
-import type { UpdateAdminProfileErrorResponse } from "../../api/auth/auth.type";
+import type {
+  AdminPasswordVerificationPurpose,
+  UpdateAdminProfileErrorResponse,
+} from "../../api/auth/auth.type";
 import { getAdminEmail, clearAdminSession } from "../../utils/adminSession";
 
 type ChangeTarget = "email" | "password" | "adminCode";
+
+const CHANGE_TARGET_PURPOSE: Record<
+  ChangeTarget,
+  AdminPasswordVerificationPurpose
+> = {
+  email: "EMAIL_CHANGE",
+  password: "PASSWORD_CHANGE",
+  adminCode: "ADMIN_CODE_CHANGE",
+};
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
@@ -173,7 +185,8 @@ const ProfileEditPage = () => {
     });
   };
 
-  const handleIdentityVerified = () => {
+  const handleIdentityVerified = (verificationToken: string) => {
+    setPasswordVerificationToken(verificationToken);
     setIsIdentitySheetOpen(false);
     if (pendingChangeTarget === "email") {
       setIsEmailSheetOpen(true);
@@ -321,10 +334,15 @@ const ProfileEditPage = () => {
       <IdentityVerificationBottomSheet
         ref={identitySheetRef}
         isOpen={isIdentitySheetOpen}
-        email={email || getAdminEmail()}
+        purpose={
+          pendingChangeTarget
+            ? CHANGE_TARGET_PURPOSE[pendingChangeTarget]
+            : "EMAIL_CHANGE"
+        }
         onClose={() => {
           setIsIdentitySheetOpen(false);
           setPendingChangeTarget(null);
+          setPasswordVerificationToken("");
         }}
         onVerified={handleIdentityVerified}
       />


### PR DESCRIPTION
## 📌 Related Issues

- RTR-321

## 📄 Tasks

- POST `/api/admin/v1/profile/password/verify` 신규 연동
- 요청: password + purpose (EMAIL_CHANGE | PASSWORD_CHANGE | ADMIN_CODE_CHANGE)
- 응답: verificationToken + expiresIn
- IdentityVerificationBottomSheet를 login 재호출 대신 이 API로 교체

## 🔔 ETC

- Bugbot: medium 1건 수정 후 clean
- Swagger: http://ec2-3-38-98-81.ap-northeast-2.compute.amazonaws.com/swagger-ui/index.html


Made with [Cursor](https://cursor.com)