### PR TITLE
[RTR-323] 관리자 비밀번호 변경 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -19,6 +19,7 @@ import type {
   UpdateAdminProfileRequest,
   VerifyAdminPasswordRequest,
   VerifyAdminPasswordResponse,
+  UpdateAdminPasswordRequest,
   LoadHomeResponse,
   LogoutResponse,
   WithdrawRequest,
@@ -199,4 +200,14 @@ export const verifyAdminPassword = async (
     data,
   );
   return response.data;
+};
+
+//
+// 7-5. 관리자 비밀번호 변경 API (PATCH)
+// 엔드포인트 : "/api/admin/v1/profile/password"
+// 성공 시 204 No Content (세션 만료)
+export const updateAdminPassword = async (
+  data: UpdateAdminPasswordRequest,
+): Promise<void> => {
+  await apiClient.patch("/api/admin/v1/profile/password", data);
 };

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -237,6 +237,22 @@ export interface VerifyAdminPasswordErrorResponse {
   detail?: string;
 }
 
+// 6-5. 관리자 비밀번호 변경
+// 엔드포인트: "/api/admin/v1/profile/password" (PATCH)
+// 성공 시 204 No Content (세션 만료)
+export interface UpdateAdminPasswordRequest {
+  newPassword: string;
+  confirmPassword: string;
+  passwordVerificationToken: string;
+}
+
+export interface UpdateAdminPasswordErrorResponse {
+  status: string;
+  code: number;
+  message: string;
+  detail?: string;
+}
+
 // 7. 홈 화면 출력 요청
 // 홈 화면 출력 요청 바디 없음
 

--- a/src/components/modals/admin/account/PasswordChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/PasswordChangeBottomSheet.tsx
@@ -10,12 +10,12 @@ import BottomSheet from "../../../BottomSheet";
 import CommonInput from "../../../CommonInput";
 import Button from "../../../Button";
 import ProfileChangeExitConfirmModal from "./ProfileChangeExitConfirmModal";
-import { useUpdateAdminProfile } from "../../../../hooks/queries/useAuthQueries";
+import { useUpdateAdminPassword } from "../../../../hooks/queries/useAuthQueries";
 import {
   isPasswordValid,
   PASSWORD_RULES,
 } from "../../../../utils/passwordValidation";
-import type { UpdateAdminProfileErrorResponse } from "../../../../api/auth/auth.type";
+import type { UpdateAdminPasswordErrorResponse } from "../../../../api/auth/auth.type";
 
 export type PasswordChangeBottomSheetHandle = {
   requestClose: () => void;
@@ -24,19 +24,21 @@ export type PasswordChangeBottomSheetHandle = {
 type PasswordChangeBottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
+  /** 비밀번호 변경 성공 후 호출. 호출측에서 로그아웃 처리한다. */
   onChanged: () => void;
+  passwordVerificationToken: string;
 };
 
 const PasswordChangeBottomSheet = forwardRef<
   PasswordChangeBottomSheetHandle,
   PasswordChangeBottomSheetProps
->(({ isOpen, onClose, onChanged }, ref) => {
+>(({ isOpen, onClose, onChanged, passwordVerificationToken }, ref) => {
   const [password, setPassword] = useState("");
   const [passwordCheck, setPasswordCheck] = useState("");
   const [bounceKey, setBounceKey] = useState(0);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
   const updateRequestIdRef = useRef(0);
-  const { mutate: updateProfile, isPending } = useUpdateAdminProfile();
+  const { mutate: updatePassword, isPending } = useUpdateAdminPassword();
 
   const handleRequestClose = () => {
     setIsExitModalOpen(true);
@@ -58,7 +60,11 @@ const PasswordChangeBottomSheet = forwardRef<
 
   const passwordMatches = password.length > 0 && password === passwordCheck;
   const rulesOk = isPasswordValid(password);
-  const canSubmit = rulesOk && passwordMatches && !isPending;
+  const canSubmit =
+    rulesOk &&
+    passwordMatches &&
+    Boolean(passwordVerificationToken) &&
+    !isPending;
 
   const handleConfirmExit = () => {
     updateRequestIdRef.current += 1;
@@ -78,15 +84,15 @@ const PasswordChangeBottomSheet = forwardRef<
 
     const requestId = ++updateRequestIdRef.current;
 
-    // RTR-323에서 비밀번호 전용 API로 교체 예정 (현재 PATCH /profile은 organizationName만 허용)
-    updateProfile(
+    updatePassword(
       {
         newPassword: password,
         confirmPassword: passwordCheck,
-      } as unknown as Parameters<typeof updateProfile>[0],
+        passwordVerificationToken,
+      },
       {
         onSuccess: () => {
-          if (requestId !== updateRequestIdRef.current) return;
+          // 세션을 만료시키는 성공은 시트 닫힘과 무관하게 반영한다
           onChanged();
           onClose();
         },
@@ -94,7 +100,7 @@ const PasswordChangeBottomSheet = forwardRef<
           if (requestId !== updateRequestIdRef.current) return;
           if (axios.isAxiosError(error)) {
             const data = error.response?.data as
-              | UpdateAdminProfileErrorResponse
+              | UpdateAdminPasswordErrorResponse
               | undefined;
             if (data?.message) {
               alert(data.message);
@@ -113,6 +119,7 @@ const PasswordChangeBottomSheet = forwardRef<
         isOpen={isOpen}
         onClose={handleRequestClose}
         title="비밀번호 변경"
+        description="변경 후 다시 로그인해야 합니다."
         sheetClassName="h-[612px] max-h-full"
         footer={
           <Button

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -14,6 +14,7 @@ import {
   verifyAdminEmailCode,
   updateAdminProfile,
   verifyAdminPassword,
+  updateAdminPassword,
 } from "../../api/auth/auth.api";
 
 //
@@ -230,6 +231,21 @@ export const useVerifyAdminPassword = () => {
     },
     onError: (error) => {
       console.error("관리자 비밀번호 확인 실패:", error);
+    },
+  });
+};
+
+//
+// 7-5. 관리자 비밀번호 변경 요청
+//
+export const useUpdateAdminPassword = () => {
+  return useMutation({
+    mutationFn: updateAdminPassword,
+    onSuccess: () => {
+      console.log("관리자 비밀번호 변경 성공");
+    },
+    onError: (error) => {
+      console.error("관리자 비밀번호 변경 실패:", error);
     },
   });
 };

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -375,8 +375,25 @@ const ProfileEditPage = () => {
       <PasswordChangeBottomSheet
         ref={passwordSheetRef}
         isOpen={isPasswordSheetOpen}
-        onClose={() => setIsPasswordSheetOpen(false)}
-        onChanged={showCompleteModal}
+        passwordVerificationToken={passwordVerificationToken}
+        onClose={() => {
+          setIsPasswordSheetOpen(false);
+          setPasswordVerificationToken("");
+        }}
+        onChanged={async () => {
+          flushSync(() => {
+            setIsSigningOut(true);
+          });
+          setIsPasswordSheetOpen(false);
+          setPasswordVerificationToken("");
+          clearAdminSession();
+          await queryClient.cancelQueries();
+          alert("비밀번호가 변경되었습니다. 다시 로그인해주세요.");
+          navigate("/login", { replace: true });
+          queueMicrotask(() => {
+            queryClient.clear();
+          });
+        }}
       />
 
       <AdminCodeChangeBottomSheet


### PR DESCRIPTION
## 📌 Related Issues

- RTR-323

## 📄 Tasks

- PATCH `/api/admin/v1/profile/password` 신규 연동
- 요청: newPassword, confirmPassword, passwordVerificationToken
- 성공 시 204 No Content + 로그아웃

## 🔔 ETC

- Bugbot: clean
- Swagger: http://ec2-3-38-98-81.ap-northeast-2.compute.amazonaws.com/swagger-ui/index.html


Made with [Cursor](https://cursor.com)