### PR TITLE
[RTR-325] 관리자 코드 변경 API 연동

### DIFF
--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -20,6 +20,7 @@ import type {
   VerifyAdminPasswordRequest,
   VerifyAdminPasswordResponse,
   UpdateAdminPasswordRequest,
+  UpdateAdminCodeRequest,
   LoadHomeResponse,
   LogoutResponse,
   WithdrawRequest,
@@ -210,4 +211,14 @@ export const updateAdminPassword = async (
   data: UpdateAdminPasswordRequest,
 ): Promise<void> => {
   await apiClient.patch("/api/admin/v1/profile/password", data);
+};
+
+//
+// 7-6. 관리자 코드 변경 API (PATCH)
+// 엔드포인트 : "/api/admin/v1/profile/admin-code"
+// 성공 시 204 No Content (로그아웃 불필요)
+export const updateAdminCode = async (
+  data: UpdateAdminCodeRequest,
+): Promise<void> => {
+  await apiClient.patch("/api/admin/v1/profile/admin-code", data);
 };

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -253,6 +253,22 @@ export interface UpdateAdminPasswordErrorResponse {
   detail?: string;
 }
 
+// 6-6. 관리자 코드 변경
+// 엔드포인트: "/api/admin/v1/profile/admin-code" (PATCH)
+// 성공 시 204 No Content (로그아웃 불필요)
+export interface UpdateAdminCodeRequest {
+  newAdminCode: string;
+  confirmAdminCode: string;
+  passwordVerificationToken: string;
+}
+
+export interface UpdateAdminCodeErrorResponse {
+  status: string;
+  code: number;
+  message: string;
+  detail?: string;
+}
+
 // 7. 홈 화면 출력 요청
 // 홈 화면 출력 요청 바디 없음
 

--- a/src/components/modals/admin/account/AdminCodeChangeBottomSheet.tsx
+++ b/src/components/modals/admin/account/AdminCodeChangeBottomSheet.tsx
@@ -10,8 +10,8 @@ import BottomSheet from "../../../BottomSheet";
 import CommonInput from "../../../CommonInput";
 import Button from "../../../Button";
 import ProfileChangeExitConfirmModal from "./ProfileChangeExitConfirmModal";
-import { useUpdateAdminProfile } from "../../../../hooks/queries/useAuthQueries";
-import type { UpdateAdminProfileErrorResponse } from "../../../../api/auth/auth.type";
+import { useUpdateAdminCode } from "../../../../hooks/queries/useAuthQueries";
+import type { UpdateAdminCodeErrorResponse } from "../../../../api/auth/auth.type";
 
 export type AdminCodeChangeBottomSheetHandle = {
   requestClose: () => void;
@@ -21,18 +21,21 @@ type AdminCodeChangeBottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
   onChanged: () => void;
+  passwordVerificationToken: string;
 };
 
 const AdminCodeChangeBottomSheet = forwardRef<
   AdminCodeChangeBottomSheetHandle,
   AdminCodeChangeBottomSheetProps
->(({ isOpen, onClose, onChanged }, ref) => {
+>(({ isOpen, onClose, onChanged, passwordVerificationToken }, ref) => {
   const [adminCode, setAdminCode] = useState("");
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
   const updateRequestIdRef = useRef(0);
-  const { mutate: updateProfile, isPending } = useUpdateAdminProfile();
+  const { mutate: updateAdminCode, isPending } = useUpdateAdminCode();
 
   const handleRequestClose = () => {
+    // 요청 진행 중 닫으면 성공/실패 레이스가 생기므로 차단한다
+    if (isPending) return;
     setIsExitModalOpen(true);
   };
 
@@ -49,9 +52,11 @@ const AdminCodeChangeBottomSheet = forwardRef<
   }, [isOpen]);
 
   const isValidCode = /^\d{6}$/.test(adminCode);
-  const canSubmit = isValidCode && !isPending;
+  const canSubmit =
+    isValidCode && Boolean(passwordVerificationToken) && !isPending;
 
   const handleConfirmExit = () => {
+    if (isPending) return;
     updateRequestIdRef.current += 1;
     setIsExitModalOpen(false);
     onClose();
@@ -60,13 +65,15 @@ const AdminCodeChangeBottomSheet = forwardRef<
   const handleSubmit = () => {
     if (!canSubmit) return;
 
+    setIsExitModalOpen(false);
     const requestId = ++updateRequestIdRef.current;
 
-    // RTR-325에서 관리자코드 전용 API로 교체 예정 (현재 PATCH /profile은 organizationName만 허용)
-    updateProfile(
-      { newAdminCode: adminCode } as unknown as Parameters<
-        typeof updateProfile
-      >[0],
+    updateAdminCode(
+      {
+        newAdminCode: adminCode,
+        confirmAdminCode: adminCode,
+        passwordVerificationToken,
+      },
       {
         onSuccess: () => {
           if (requestId !== updateRequestIdRef.current) return;
@@ -77,7 +84,7 @@ const AdminCodeChangeBottomSheet = forwardRef<
           if (requestId !== updateRequestIdRef.current) return;
           if (axios.isAxiosError(error)) {
             const data = error.response?.data as
-              | UpdateAdminProfileErrorResponse
+              | UpdateAdminCodeErrorResponse
               | undefined;
             if (data?.message) {
               alert(data.message);

--- a/src/hooks/queries/useAuthQueries.ts
+++ b/src/hooks/queries/useAuthQueries.ts
@@ -15,6 +15,7 @@ import {
   updateAdminProfile,
   verifyAdminPassword,
   updateAdminPassword,
+  updateAdminCode,
 } from "../../api/auth/auth.api";
 
 //
@@ -246,6 +247,21 @@ export const useUpdateAdminPassword = () => {
     },
     onError: (error) => {
       console.error("관리자 비밀번호 변경 실패:", error);
+    },
+  });
+};
+
+//
+// 7-6. 관리자 코드 변경 요청
+//
+export const useUpdateAdminCode = () => {
+  return useMutation({
+    mutationFn: updateAdminCode,
+    onSuccess: () => {
+      console.log("관리자 코드 변경 성공");
+    },
+    onError: (error) => {
+      console.error("관리자 코드 변경 실패:", error);
     },
   });
 };

--- a/src/pages/admin/ProfileEditPage.tsx
+++ b/src/pages/admin/ProfileEditPage.tsx
@@ -399,8 +399,15 @@ const ProfileEditPage = () => {
       <AdminCodeChangeBottomSheet
         ref={adminCodeSheetRef}
         isOpen={isAdminCodeSheetOpen}
-        onClose={() => setIsAdminCodeSheetOpen(false)}
-        onChanged={showCompleteModal}
+        passwordVerificationToken={passwordVerificationToken}
+        onClose={() => {
+          setIsAdminCodeSheetOpen(false);
+          setPasswordVerificationToken("");
+        }}
+        onChanged={() => {
+          setPasswordVerificationToken("");
+          showCompleteModal();
+        }}
       />
 
       <ProfileChangeCompleteModal


### PR DESCRIPTION
## 📌 Related Issues

- RTR-325

## 📄 Tasks

- PATCH `/api/admin/v1/profile/admin-code` 신규 연동
- 요청: newAdminCode, confirmAdminCode, passwordVerificationToken
- 성공 시 204 No Content (로그아웃 불필요)

## 🔔 ETC

- Bugbot: medium 다수 수정 후 clean
- Swagger: http://ec2-3-38-98-81.ap-northeast-2.compute.amazonaws.com/swagger-ui/index.html


Made with [Cursor](https://cursor.com)