### PR TITLE
멤버십 조회 경로를 /memberships/current 로 맞춘다

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -391,11 +391,11 @@ export const registerAdminCoupon = async ({
 
 // 현재 멤버십 상태 조회
 // - 이용권 목록(쿠폰/구독) 화면에서 현재 이용권 정보를 표시
-// GET /api/admin/v1/membership
+// GET /api/admin/v1/memberships/current
 export const requestAdminMembership =
   async (): Promise<AdminMembershipResponse> => {
     const response = await apiClient.get<AdminMembershipResponse>(
-      "/api/admin/v1/membership",
+      "/api/admin/v1/memberships/current",
     );
     return response.data;
   };

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -355,7 +355,7 @@ export interface AdminCouponErrorResponse {
 }
 
 // 현재 멤버십 상태 조회 응답
-// GET /api/admin/v1/membership
+// GET /api/admin/v1/memberships/current
 export interface AdminMembershipCouponInfo {
   couponName: string;
   couponDescription: string;
@@ -374,9 +374,11 @@ export interface AdminMembershipResponse {
   startAt: string; // YYYY-MM-DD
   endAt: string; // YYYY-MM-DD
   nextBillingAt?: string; // YYYY-MM-DD
+  payedAmount?: number;
 }
 
 // 멤버십 조회 실패 시 공통 에러 응답
+// - 400: code 12201 (이용권에서 쿠폰 정보를 가져올 수 없음)
 // - 400: code 12202 (이용권에서 구독 정보를 가져올 수 없음)
 // - 404: code 3004 (존재하지 않는 단체)
 export interface AdminMembershipErrorResponse {

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -397,7 +397,7 @@ export const useRegisterAdminCoupon = () => {
 
 // 현재 멤버십 상태 조회
 // - 멤버십 이용 현황, 이용권 목록 > 구독 이용권 탭 등에서 사용
-// GET /api/admin/v1/membership
+// GET /api/admin/v1/memberships/current
 export const useAdminMembership = () => {
   return useQuery<AdminMembershipResponse>({
     queryKey: ["adminMembership"],


### PR DESCRIPTION
## 📌 Related Issues

- 관련 이슈 없음 (Swagger 경로 오기 수정)

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요?
- [x] 빌드가 성공했나요? (`npx tsc -b --noEmit`)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- 멤버십 상태 조회 엔드포인트를 `GET /api/admin/v1/membership` → `GET /api/admin/v1/memberships/current` 로 수정
- 응답 타입에 Swagger의 `payedAmount`를 optional로 추가

## ⭐ PR Point (To Reviewer)

존재하지 않는 `/membership` 경로는 인증된 요청에서 403이 났습니다. 실제 스펙 경로는 `/memberships/current` 입니다.

## 📷 Screenshot

## 🔔 ETC

Bugbot: 이슈 없음

Made with [Cursor](https://cursor.com)