### PR TITLE
[RTR-332] 결제 수단 등록 API 연동 & 분기 처리 / 결제수단 등록 화면 UI 수정 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "retrivr-web",
       "version": "0.0.0",
       "dependencies": {
+        "@portone/browser-sdk": "^0.1.9",
         "@tailwindcss/postcss": "^4.1.18",
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.5",
@@ -1029,6 +1030,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@portone/browser-sdk": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@portone/browser-sdk/-/browser-sdk-0.1.9.tgz",
+      "integrity": "sha512-GiLziqmKKSrorjWDvWjPhtD1nBd4zlY1crIPX5Kisx797MQYveqhtSMYwuyjRgwgInfEWonXjXWkHd5bTFUiWQ=="
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@portone/browser-sdk": "^0.1.9",
     "@tailwindcss/postcss": "^4.1.18",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.5",

--- a/src/lib/portoneBilling.ts
+++ b/src/lib/portoneBilling.ts
@@ -7,6 +7,7 @@ import {
 
 const ISSUE_NAME = "Retrivr 정기결제 수단 등록";
 const OPTION_STORAGE_KEY = "retrivr.portone.paymentMethodOption";
+const BILLING_KEY_SAVE_STORAGE_KEY = "retrivr.portone.billingKeySave";
 const PORTONE_OVERLAY_ID = "imp-iframe-wrapper";
 
 type PortoneMethodConfig = {
@@ -60,6 +61,54 @@ export const readPortoneRegisterOption = () => {
 
 export const clearPortoneRegisterOption = () => {
   sessionStorage.removeItem(OPTION_STORAGE_KEY);
+};
+
+type BillingKeySaveState = {
+  billingKey: string;
+  status: "saving" | "saved";
+};
+
+const readBillingKeySaveState = (): BillingKeySaveState | null => {
+  const stored = sessionStorage.getItem(BILLING_KEY_SAVE_STORAGE_KEY);
+  if (!stored) return null;
+  try {
+    const parsed = JSON.parse(stored) as BillingKeySaveState;
+    if (
+      typeof parsed.billingKey === "string" &&
+      (parsed.status === "saving" || parsed.status === "saved")
+    ) {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
+export const claimPortoneBillingKeySave = (billingKey: string) => {
+  const current = readBillingKeySaveState();
+  if (current?.billingKey === billingKey) {
+    return current.status === "saved" ? "already-saved" : "in-flight";
+  }
+  sessionStorage.setItem(
+    BILLING_KEY_SAVE_STORAGE_KEY,
+    JSON.stringify({ billingKey, status: "saving" } satisfies BillingKeySaveState),
+  );
+  return "claimed";
+};
+
+export const markPortoneBillingKeySaved = (billingKey: string) => {
+  sessionStorage.setItem(
+    BILLING_KEY_SAVE_STORAGE_KEY,
+    JSON.stringify({ billingKey, status: "saved" } satisfies BillingKeySaveState),
+  );
+};
+
+export const releasePortoneBillingKeySave = (billingKey: string) => {
+  const current = readBillingKeySaveState();
+  if (current?.billingKey === billingKey) {
+    sessionStorage.removeItem(BILLING_KEY_SAVE_STORAGE_KEY);
+  }
 };
 
 export const closePortoneOverlay = () => {
@@ -118,7 +167,6 @@ export type PortoneCheckoutDevice = "desktop" | "mobile";
 export const issuePortoneBillingKey = async ({
   option,
   customer,
-  checkoutDevice,
 }: {
   option: PaymentMethodRegisterOption;
   customer?: {
@@ -127,7 +175,6 @@ export const issuePortoneBillingKey = async ({
     email?: string;
     phoneNumber?: string;
   };
-  checkoutDevice?: PortoneCheckoutDevice;
 }): Promise<PortoneIssueResult> => {
   const storeId = readEnv("VITE_PORTONE_STORE_ID");
   const config = METHOD_CONFIG[option];
@@ -151,9 +198,9 @@ export const issuePortoneBillingKey = async ({
     ...(customer?.phoneNumber ? { phoneNumber: customer.phoneNumber } : {}),
   };
 
-  const useMobileCheckout =
-    checkoutDevice === "mobile" ||
-    (checkoutDevice !== "desktop" && isPortoneMobileDevice());
+  // 포트원 창 타입은 SDK가 User-Agent로 고른다. PC iframe에 redirectUrl을 넣으면
+  // 프로미스 성공과 쿼리 복귀가 겹쳐 같은 빌링키로 POST가 두 번 갈 수 있다.
+  const useMobileRedirect = isPortoneMobileDevice();
 
   const response = await PortOne.requestIssueBillingKey({
     storeId,
@@ -161,9 +208,7 @@ export const issuePortoneBillingKey = async ({
     billingKeyMethod: config.billingKeyMethod,
     issueId: `retrivr-${crypto.randomUUID()}`,
     issueName: ISSUE_NAME,
-    // 노트북/PC는 리디렉션하지 않는다. 카카오페이는 PC iframe에서 QR을 보여 주고,
-    // 휴대폰만 카카오톡으로 보낸다. 화면 너비(402px 셸)는 쓰지 않는다.
-    ...(useMobileCheckout ? { redirectUrl: buildRedirectUrl() } : {}),
+    ...(useMobileRedirect ? { redirectUrl: buildRedirectUrl() } : {}),
     windowType: {
       pc: "IFRAME",
       mobile: "REDIRECTION",

--- a/src/lib/portoneBilling.ts
+++ b/src/lib/portoneBilling.ts
@@ -1,0 +1,201 @@
+import * as PortOne from "@portone/browser-sdk/v2";
+import type { AdminPaymentMethodProvider } from "../api/admin/admin.type";
+import {
+  REGISTER_OPTION_PROVIDER,
+  type PaymentMethodRegisterOption,
+} from "../types/paymentMethod";
+
+const ISSUE_NAME = "Retrivr 정기결제 수단 등록";
+const OPTION_STORAGE_KEY = "retrivr.portone.paymentMethodOption";
+const PORTONE_OVERLAY_ID = "imp-iframe-wrapper";
+
+type PortoneMethodConfig = {
+  provider: AdminPaymentMethodProvider;
+  billingKeyMethod: "CARD" | "EASY_PAY";
+  channelKeyEnv:
+    | "VITE_PORTONE_CHANNEL_KEY_KAKAOPAY"
+    | "VITE_PORTONE_CHANNEL_KEY_KGINICIS";
+};
+
+const METHOD_CONFIG: Record<PaymentMethodRegisterOption, PortoneMethodConfig> =
+  {
+    kakao: {
+      provider: REGISTER_OPTION_PROVIDER.kakao,
+      billingKeyMethod: "EASY_PAY",
+      channelKeyEnv: "VITE_PORTONE_CHANNEL_KEY_KAKAOPAY",
+    },
+    card: {
+      provider: REGISTER_OPTION_PROVIDER.card,
+      billingKeyMethod: "CARD",
+      channelKeyEnv: "VITE_PORTONE_CHANNEL_KEY_KGINICIS",
+    },
+  };
+
+export type PortoneIssueResult =
+  | { ok: true; billingKey: string; provider: AdminPaymentMethodProvider }
+  | {
+      ok: false;
+      reason: "cancelled" | "failed" | "not_configured";
+      message: string;
+    };
+
+const readEnv = (key: keyof ImportMetaEnv) => import.meta.env[key]?.trim() ?? "";
+
+export const getPortoneProvider = (option: PaymentMethodRegisterOption) =>
+  METHOD_CONFIG[option].provider;
+
+export const savePortoneRegisterOption = (
+  option: PaymentMethodRegisterOption,
+) => {
+  sessionStorage.setItem(OPTION_STORAGE_KEY, option);
+};
+
+export const readPortoneRegisterOption = () => {
+  const stored = sessionStorage.getItem(OPTION_STORAGE_KEY);
+  if (stored === "kakao" || stored === "card") {
+    return stored;
+  }
+  return null;
+};
+
+export const clearPortoneRegisterOption = () => {
+  sessionStorage.removeItem(OPTION_STORAGE_KEY);
+};
+
+export const closePortoneOverlay = () => {
+  document.getElementById(PORTONE_OVERLAY_ID)?.remove();
+};
+
+/**
+ * 포트원 SDK와 같이 User-Agent로 실제 휴대기기를 판별한다.
+ * 관리자 화면이 402px 셸이어도 PC 브라우저는 PC로 본다.
+ */
+export const isPortoneMobileDevice = () => {
+  const userAgent = navigator.userAgent;
+  if (/Mobi|Android|iPhone|iPod/i.test(userAgent)) return true;
+  if (/iPad/i.test(userAgent)) return true;
+  return /Macintosh/i.test(userAgent) && navigator.maxTouchPoints > 1;
+};
+
+export const getPortoneRedirectResult = (
+  params: URLSearchParams,
+): { billingKey: string } | { error: string } | null => {
+  const billingKey = params.get("billingKey")?.trim() ?? "";
+  const code = params.get("code")?.trim() ?? "";
+  const message = params.get("message")?.trim() ?? "";
+
+  if (code) {
+    return {
+      error: message || "결제수단 등록이 취소되었거나 완료되지 않았습니다.",
+    };
+  }
+  if (billingKey && billingKey !== "NEEDS_CONFIRMATION") {
+    return { billingKey };
+  }
+  return null;
+};
+
+const buildRedirectUrl = () => {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("billingKey");
+  url.searchParams.delete("code");
+  url.searchParams.delete("message");
+  return url.toString();
+};
+
+const hasIssuedBillingKey = (response: {
+  transactionType?: string;
+  code?: string;
+  billingKey?: string;
+}) =>
+  response.transactionType === "ISSUE_BILLING_KEY" &&
+  !response.code &&
+  Boolean(response.billingKey) &&
+  response.billingKey !== "NEEDS_CONFIRMATION";
+
+export type PortoneCheckoutDevice = "desktop" | "mobile";
+
+export const issuePortoneBillingKey = async ({
+  option,
+  customer,
+  checkoutDevice,
+}: {
+  option: PaymentMethodRegisterOption;
+  customer?: {
+    customerId?: string;
+    fullName?: string;
+    email?: string;
+    phoneNumber?: string;
+  };
+  checkoutDevice?: PortoneCheckoutDevice;
+}): Promise<PortoneIssueResult> => {
+  const storeId = readEnv("VITE_PORTONE_STORE_ID");
+  const config = METHOD_CONFIG[option];
+  const channelKey = readEnv(config.channelKeyEnv);
+
+  if (!storeId || !channelKey) {
+    return {
+      ok: false,
+      reason: "not_configured",
+      message:
+        "포트원 storeId와 채널 키가 아직 설정되지 않아 결제창을 열 수 없습니다.",
+    };
+  }
+
+  savePortoneRegisterOption(option);
+
+  const customerPayload = {
+    ...(customer?.customerId ? { customerId: customer.customerId } : {}),
+    ...(customer?.fullName ? { fullName: customer.fullName } : {}),
+    ...(customer?.email ? { email: customer.email } : {}),
+    ...(customer?.phoneNumber ? { phoneNumber: customer.phoneNumber } : {}),
+  };
+
+  const useMobileCheckout =
+    checkoutDevice === "mobile" ||
+    (checkoutDevice !== "desktop" && isPortoneMobileDevice());
+
+  const response = await PortOne.requestIssueBillingKey({
+    storeId,
+    channelKey,
+    billingKeyMethod: config.billingKeyMethod,
+    issueId: `retrivr-${crypto.randomUUID()}`,
+    issueName: ISSUE_NAME,
+    // 노트북/PC는 리디렉션하지 않는다. 카카오페이는 PC iframe에서 QR을 보여 주고,
+    // 휴대폰만 카카오톡으로 보낸다. 화면 너비(402px 셸)는 쓰지 않는다.
+    ...(useMobileCheckout ? { redirectUrl: buildRedirectUrl() } : {}),
+    windowType: {
+      pc: "IFRAME",
+      mobile: "REDIRECTION",
+    },
+    locale: "KO_KR",
+    offerPeriod: {
+      interval: "1m",
+    },
+    ...(Object.keys(customerPayload).length > 0
+      ? { customer: customerPayload }
+      : {}),
+  });
+
+  if (!response) {
+    return {
+      ok: false,
+      reason: "cancelled",
+      message: "결제수단 등록이 취소되었습니다.",
+    };
+  }
+
+  if (!hasIssuedBillingKey(response)) {
+    return {
+      ok: false,
+      reason: "failed",
+      message: response.message || "빌링키 발급에 실패했습니다.",
+    };
+  }
+
+  return {
+    ok: true,
+    billingKey: response.billingKey,
+    provider: config.provider,
+  };
+};

--- a/src/pages/admin/PaymentMethodRegisterPage.tsx
+++ b/src/pages/admin/PaymentMethodRegisterPage.tsx
@@ -1,31 +1,196 @@
-import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import axios from "axios";
 import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";
+import ErrorModal from "../../components/modals/ErrorModal";
+import { useQueryClient } from "@tanstack/react-query";
+import type { AdminPaymentMethodErrorResponse } from "../../api/admin/admin.type";
+import type { AdminProfileResponse } from "../../api/auth/auth.type";
+import { useCreateAdminPaymentMethod } from "../../hooks/queries/useAdminQueries";
 import {
   REGISTER_OPTION_LABEL,
   type PaymentMethodRegisterOption,
 } from "../../types/paymentMethod";
+import { getAdminEmail } from "../../utils/adminSession";
 import { resolveMembershipReturnTo } from "../../utils/safeReturnTo";
+import {
+  clearPortoneRegisterOption,
+  closePortoneOverlay,
+  getPortoneProvider,
+  getPortoneRedirectResult,
+  isPortoneMobileDevice,
+  issuePortoneBillingKey,
+  readPortoneRegisterOption,
+  type PortoneCheckoutDevice,
+} from "../../lib/portoneBilling";
 
-const REGISTER_OPTIONS: PaymentMethodRegisterOption[] = [
-  "kakao",
-  "toss",
-  "card",
-];
+const REGISTER_OPTIONS: PaymentMethodRegisterOption[] = ["kakao", "card"];
+const SUCCESS_MESSAGE = "결제 수단 등록이 완료되었습니다.";
+
+const toPortonePhoneNumber = (value: string) => {
+  const digits = value.replace(/\D/g, "");
+  if (digits.length === 11) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  }
+  if (digits.length === 10) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
+  }
+  return "";
+};
+
+const getPaymentMethodErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as
+      | AdminPaymentMethodErrorResponse
+      | undefined;
+    if (data?.message) return data.message;
+  }
+  return fallback;
+};
 
 const PaymentMethodRegisterPage = () => {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const returnTo = resolveMembershipReturnTo(searchParams.get("returnTo"));
+  const shouldSetPrimaryOnRegister = returnTo.startsWith(
+    "/membership/subscribe",
+  );
+  const queryClient = useQueryClient();
+  const cachedProfile = queryClient.getQueryData<AdminProfileResponse>([
+    "adminProfile",
+  ]);
+  const { mutateAsync: createPaymentMethod, isPending: isCreating } =
+    useCreateAdminPaymentMethod();
   const [selectedOption, setSelectedOption] =
-    useState<PaymentMethodRegisterOption>("card");
+    useState<PaymentMethodRegisterOption>("kakao");
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isIssuing, setIsIssuing] = useState(false);
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [checkoutDevice, setCheckoutDevice] = useState<PortoneCheckoutDevice>(
+    () => (isPortoneMobileDevice() ? "mobile" : "desktop"),
+  );
+  const handledRedirectRef = useRef(false);
+  const abortedRef = useRef(false);
 
-  const handleRegister = () => {
-    setErrorMessage(
-      "결제 수단 등록은 PortOne billingKey 발급 연동 후 사용할 수 있습니다.",
-    );
+  const isBusy = isIssuing || isCreating;
+
+  const abandonRegistration = () => {
+    abortedRef.current = true;
+    closePortoneOverlay();
+    clearPortoneRegisterOption();
+  };
+
+  const saveIssuedBillingKey = async ({
+    option,
+    billingKey,
+  }: {
+    option: PaymentMethodRegisterOption;
+    billingKey: string;
+  }) => {
+    if (abortedRef.current) return;
+
+    try {
+      await createPaymentMethod({
+        provider: getPortoneProvider(option),
+        billingKey,
+        isDefault: shouldSetPrimaryOnRegister,
+      });
+      if (abortedRef.current) return;
+      clearPortoneRegisterOption();
+      setSuccessMessage(SUCCESS_MESSAGE);
+    } catch (error) {
+      if (abortedRef.current) return;
+      setErrorMessage(
+        getPaymentMethodErrorMessage(
+          error,
+          "결제 수단 등록에 실패했습니다. 다시 시도해주세요.",
+        ),
+      );
+    }
+  };
+
+  useEffect(() => {
+    abortedRef.current = false;
+    return () => {
+      abortedRef.current = true;
+      closePortoneOverlay();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (handledRedirectRef.current) return;
+    const redirectResult = getPortoneRedirectResult(searchParams);
+    if (!redirectResult) return;
+    handledRedirectRef.current = true;
+
+    const cleanedParams = new URLSearchParams(searchParams);
+    cleanedParams.delete("billingKey");
+    cleanedParams.delete("code");
+    cleanedParams.delete("message");
+    navigate({ search: cleanedParams.toString() }, { replace: true });
+
+    if (abortedRef.current) return;
+
+    const option = readPortoneRegisterOption();
+    if ("error" in redirectResult) {
+      setErrorMessage(redirectResult.error);
+      return;
+    }
+    if (!option) {
+      setErrorMessage("결제수단 등록 정보를 확인하지 못했습니다.");
+      return;
+    }
+    void saveIssuedBillingKey({
+      option,
+      billingKey: redirectResult.billingKey,
+    });
+    // 리디렉션 복귀 시에만 한 번 처리한다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  const handleRegister = async () => {
+    if (isBusy || abortedRef.current) return;
+
+    const cardPhoneNumber =
+      selectedOption === "card" ? toPortonePhoneNumber(phoneNumber) : "";
+    if (selectedOption === "card" && !cardPhoneNumber) {
+      setErrorMessage("카드 등록에는 연락처가 필요합니다.");
+      return;
+    }
+
+    setIsIssuing(true);
+    const organizationId = localStorage.getItem("orgId")?.trim();
+    const result = await issuePortoneBillingKey({
+      option: selectedOption,
+      checkoutDevice,
+      customer: {
+        customerId: organizationId || undefined,
+        fullName: cachedProfile?.organizationName || "Retrivr 관리자",
+        email: getAdminEmail() || undefined,
+        phoneNumber: cardPhoneNumber || undefined,
+      },
+    });
+    setIsIssuing(false);
+
+    if (abortedRef.current) return;
+
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      return;
+    }
+
+    await saveIssuedBillingKey({
+      option: selectedOption,
+      billingKey: result.billingKey,
+    });
+  };
+
+  const handleBack = () => {
+    abandonRegistration();
+    navigate(returnTo);
   };
 
   return (
@@ -33,7 +198,7 @@ const PaymentMethodRegisterPage = () => {
       <Header
         name="결제 수단 관리"
         pageName="결제 수단 등록"
-        backTo={returnTo}
+        onBackClick={handleBack}
       />
 
       <div className="relative flex flex-1 flex-col overflow-y-auto no-scrollbar px-8 pb-28 pt-8 font-[Pretendard]">
@@ -54,8 +219,11 @@ const PaymentMethodRegisterPage = () => {
               <button
                 key={option}
                 type="button"
+                disabled={isBusy}
                 onClick={() => setSelectedOption(option)}
-                className={`flex h-[52px] w-full items-center justify-center rounded-[7.5px] border border-[#e6eaed] text-14px font-semibold leading-5 cursor-pointer ${
+                className={`flex h-[52px] w-full items-center justify-center rounded-[7.5px] border border-[#e6eaed] text-14px font-semibold leading-5 ${
+                  isBusy ? "cursor-not-allowed opacity-60" : "cursor-pointer"
+                } ${
                   isSelected
                     ? "bg-secondary-4 text-primary"
                     : "bg-neutral-white text-neutral-gray-2"
@@ -67,21 +235,94 @@ const PaymentMethodRegisterPage = () => {
           })}
         </div>
 
+        {selectedOption === "kakao" ? (
+          <section className="mt-6 flex flex-col gap-3">
+            <h3 className="text-14px font-semibold leading-5 text-neutral-gray-2">
+              지금 사용 중인 기기
+            </h3>
+            <div className="flex gap-2">
+              {(
+                [
+                  ["desktop", "노트북 / PC"],
+                  ["mobile", "휴대폰"],
+                ] as const
+              ).map(([device, label]) => {
+                const isSelected = checkoutDevice === device;
+                return (
+                  <button
+                    key={device}
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => setCheckoutDevice(device)}
+                    className={`flex h-[44px] flex-1 items-center justify-center rounded-[7.5px] border border-[#e6eaed] text-13px font-semibold leading-5 ${
+                      isBusy ? "cursor-not-allowed opacity-60" : "cursor-pointer"
+                    } ${
+                      isSelected
+                        ? "bg-secondary-4 text-primary"
+                        : "bg-neutral-white text-neutral-gray-2"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-12px font-normal leading-[1.4] text-neutral-gray-3">
+              {checkoutDevice === "desktop"
+                ? "카카오페이 창에 QR이 표시됩니다. 휴대폰 카카오톡으로 스캔해주세요. 노트북 카카오톡 앱으로는 등록할 수 없습니다."
+                : "휴대폰 카카오톡 앱에서 결제수단을 등록합니다."}
+            </p>
+          </section>
+        ) : null}
+
+        {selectedOption === "card" ? (
+          <label className="mt-6 flex flex-col gap-2">
+            <span className="text-14px font-semibold leading-5 text-neutral-gray-2">
+              연락처
+            </span>
+            <input
+              type="tel"
+              inputMode="numeric"
+              autoComplete="tel"
+              disabled={isBusy}
+              value={phoneNumber}
+              onChange={(event) => setPhoneNumber(event.target.value)}
+              placeholder="010-0000-0000"
+              className="h-[52px] w-full rounded-[7.5px] border border-[#e6eaed] bg-neutral-white px-4 text-14px font-normal leading-5 text-neutral-gray-1 outline-none placeholder:text-neutral-gray-3 disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <span className="text-12px font-normal leading-[1.4] text-neutral-gray-3">
+              KG이니시스 카드 등록에 필요한 연락처입니다.
+            </span>
+          </label>
+        ) : null}
+
         <div className="pointer-events-none absolute inset-x-0 bottom-0 px-8 pb-8">
           <button
             type="button"
-            onClick={handleRegister}
-            className="pointer-events-auto flex h-[50px] w-full items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-primary cursor-pointer"
+            disabled={isBusy}
+            onClick={() => {
+              void handleRegister();
+            }}
+            className="pointer-events-auto flex h-[50px] w-full items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-primary disabled:cursor-not-allowed disabled:opacity-60 cursor-pointer"
           >
-            등록하기
+            {isBusy ? "등록 중..." : "등록하기"}
           </button>
         </div>
       </div>
 
       <ConfirmModal
+        isOpen={successMessage !== null}
+        onClose={() => {
+          setSuccessMessage(null);
+          navigate(returnTo);
+        }}
+        message={successMessage ?? ""}
+        confirmText="확인"
+      />
+      <ErrorModal
         isOpen={errorMessage !== null}
         onClose={() => setErrorMessage(null)}
-        message={errorMessage ?? ""}
+        message1={errorMessage ?? ""}
         confirmText="확인"
       />
     </Layout>

--- a/src/pages/admin/PaymentMethodRegisterPage.tsx
+++ b/src/pages/admin/PaymentMethodRegisterPage.tsx
@@ -16,13 +16,16 @@ import {
 import { getAdminEmail } from "../../utils/adminSession";
 import { resolveMembershipReturnTo } from "../../utils/safeReturnTo";
 import {
+  claimPortoneBillingKeySave,
   clearPortoneRegisterOption,
   closePortoneOverlay,
   getPortoneProvider,
   getPortoneRedirectResult,
   isPortoneMobileDevice,
   issuePortoneBillingKey,
+  markPortoneBillingKeySaved,
   readPortoneRegisterOption,
+  releasePortoneBillingKeySave,
   type PortoneCheckoutDevice,
 } from "../../lib/portoneBilling";
 
@@ -92,16 +95,26 @@ const PaymentMethodRegisterPage = () => {
   }) => {
     if (abortedRef.current) return;
 
+    const claim = claimPortoneBillingKeySave(billingKey);
+    if (claim === "in-flight") return;
+    if (claim === "already-saved") {
+      clearPortoneRegisterOption();
+      setSuccessMessage(SUCCESS_MESSAGE);
+      return;
+    }
+
     try {
       await createPaymentMethod({
         provider: getPortoneProvider(option),
         billingKey,
         isDefault: shouldSetPrimaryOnRegister,
       });
+      markPortoneBillingKeySaved(billingKey);
       if (abortedRef.current) return;
       clearPortoneRegisterOption();
       setSuccessMessage(SUCCESS_MESSAGE);
     } catch (error) {
+      releasePortoneBillingKeySave(billingKey);
       if (abortedRef.current) return;
       setErrorMessage(
         getPaymentMethodErrorMessage(
@@ -165,7 +178,6 @@ const PaymentMethodRegisterPage = () => {
     const organizationId = localStorage.getItem("orgId")?.trim();
     const result = await issuePortoneBillingKey({
       option: selectedOption,
-      checkoutDevice,
       customer: {
         customerId: organizationId || undefined,
         fullName: cachedProfile?.organizationName || "Retrivr 관리자",

--- a/src/types/paymentMethod.ts
+++ b/src/types/paymentMethod.ts
@@ -2,7 +2,7 @@ import type { AdminPaymentMethodProvider } from "../api/admin/admin.type";
 
 export type PaymentMethodProvider = AdminPaymentMethodProvider;
 
-export type PaymentMethodRegisterOption = "kakao" | "toss" | "card";
+export type PaymentMethodRegisterOption = "kakao" | "card";
 
 export type PaymentMethod = {
   id: string;
@@ -21,7 +21,6 @@ export const PAYMENT_PROVIDER_LABEL: Record<PaymentMethodProvider, string> = {
 export const REGISTER_OPTION_LABEL: Record<PaymentMethodRegisterOption, string> =
   {
     kakao: "카카오페이",
-    toss: "토스페이",
     card: "카드 등록",
   };
 
@@ -30,7 +29,6 @@ export const REGISTER_OPTION_PROVIDER: Record<
   PaymentMethodProvider
 > = {
   kakao: "KAKAOPAY",
-  toss: "TOSSPAY",
   card: "KGINICIS",
 };
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PORTONE_STORE_ID?: string;
+  readonly VITE_PORTONE_CHANNEL_KEY_KAKAOPAY?: string;
+  readonly VITE_PORTONE_CHANNEL_KEY_KGINICIS?: string;
+}


### PR DESCRIPTION
## 📌 Related Issues

- [RTR-332] 결제 수단 추가 API

목록·대표 변경·단건 조회·삭제는 #171에서 연동했다. 이 PR은 등록 화면에서 포트원 빌링키 발급 후 `POST /payment-methods`를 호출한다.

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- [RTR-332] 포트원 `requestIssueBillingKey`로 빌링키를 발급한 뒤 `POST /api/admin/v1/payment-methods`에 저장한다.
- 등록 수단은 카카오페이·KG이니시스 카드만 노출한다.
- 등록 중 뒤로 가기·창 닫기는 성공 모달/저장으로 처리하지 않는다. 취소·실패는 `ErrorModal`, 성공만 `ConfirmModal`을 쓴다.
- 노트북/PC는 카카오페이 iframe(QR)을 쓰고, 실제 휴대폰만 카카오톡 리디렉션을 쓴다. 카카오페이 선택 시 기기(노트북 / 휴대폰)를 고를 수 있다.

## ⭐ PR Point (To Reviewer)

- 포트원 storeId·채널 키는 gitignored `.env.development.local`의 `VITE_PORTONE_*`만 사용한다. `PORTONE_API_SECRET`은 프론트에 넣지 않는다.
- PC에서 `redirectUrl`을 넣으면 뒤로 가기 후에도 `billingKey` 쿼리로 성공 처리될 수 있어, 모바일 리디렉션일 때만 `redirectUrl`을 넘긴다.
- 카카오페이는 PC iframe / 모바일 리디렉션만 허용한다. 노트북 카카오톡 앱으로는 등록할 수 없고, QR을 휴대폰으로 스캔하는 흐름이다.

## 📷 Screenshot

로컬에서 카카오페이·카드 등록 후 목록 반영을 확인한다.

## 🔔 ETC

로컬 실행 전 `VITE_PORTONE_STORE_ID`, `VITE_PORTONE_CHANNEL_KEY_KAKAOPAY`, `VITE_PORTONE_CHANNEL_KEY_KGINICIS`를 `.env.development.local`에 넣고 dev 서버를 재시작한다.