### PR TITLE
랜딩 페이지 버튼 하단에 사업자 정보를 추가한다

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,6 +2,11 @@ import { Layout } from "../components/Layout";
 import Button from "../components/Button";
 import { useNavigate } from "react-router-dom";
 
+const BUSINESS_INFO_URL =
+  "https://www.ftc.go.kr/bizCommPop.do?wrkr_no=8706400978";
+
+const footerLinkClass = "text-inherit underline";
+
 const LandingPage = () => {
   const navigate = useNavigate();
 
@@ -24,19 +29,39 @@ const LandingPage = () => {
         </p>
       </div>
       {/* 버튼 영역 - 대여하기, 관리자로 로그인 */}
-      <div className="flex flex-col justify-center items-center w-full mt-auto mb-12 gap-2">
-        {/* TODO: 라우팅 경로 짜기 */}
-        <Button
-          variant="primary"
-          size="lg"
-          onClick={() => navigate("/client-search")}
-        >
-          대여하기
-        </Button>
-        {/* 관리자 로그인 버튼 : /login 으로 이동 */}
-        <Button variant="gray" size="lg" onClick={() => navigate("/login")}>
-          관리자로 로그인
-        </Button>
+      <div className="flex flex-col justify-center items-center w-full mt-auto mb-12">
+        <div className="flex w-full flex-col items-center gap-2">
+          {/* TODO: 라우팅 경로 짜기 */}
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={() => navigate("/client-search")}
+          >
+            대여하기
+          </Button>
+          {/* 관리자 로그인 버튼 : /login 으로 이동 */}
+          <Button variant="gray" size="lg" onClick={() => navigate("/login")}>
+            관리자로 로그인
+          </Button>
+        </div>
+        <p className="mt-[30px] w-full max-w-[322px] text-center text-10px font-normal leading-[1.3] text-neutral-gray-3 whitespace-pre-wrap">
+          Retrivr  |  대표자: 박다솔  |  사업자등록번호: 870-64-00978
+          {"\n"}
+          <span className={footerLinkClass}>이용약관</span>
+          {"  |  "}
+          <span className={footerLinkClass}>개인정보처리방침</span>
+          {"  | E-mail: retrivr.service@gmail.com\n"}
+          {"Instagram: @retrivr_official  |  "}
+          <a
+            href={BUSINESS_INFO_URL}
+            target="_blank"
+            rel="noreferrer"
+            className={footerLinkClass}
+          >
+            사업자 추가 정보
+          </a>
+          {"  주소: 경기도 파주시 후곡로 77"}
+        </p>
       </div>
     </Layout>
   );


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- Figma `최종 1. 랜딩페이지`(`3469:33976`) 기준으로 버튼 하단에 사업자 정보 푸터를 추가한다.
- 이용약관·개인정보처리방침·사업자 추가 정보는 피그마와 같이 밑줄 처리한다.
- 사업자 추가 정보는 공정위 사업자 정보 조회 팝업으로 연결한다.

## ⭐ PR Point (To Reviewer)

- 버튼 문구(`관리자로 로그인`)는 기존 구현을 유지했다.
- 이용약관/개인정보처리방침은 공개 열람 페이지가 없어 동의 플로우(`/terms`)로 보내지 않고, 피그마 밑줄만 맞췄다.

## 📷 Screenshot

## 🔔 ETC

- Figma: https://www.figma.com/design/n2RVOSB5OfnWlnpSNqOB0J/Retrivr?node-id=3469-33976


Made with [Cursor](https://cursor.com)