### PR TITLE
랜딩 푸터에서 사업자 추가 정보 클릭 시 주소를 표시한다

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,14 +1,13 @@
+import { useState } from "react";
 import { Layout } from "../components/Layout";
 import Button from "../components/Button";
 import { useNavigate } from "react-router-dom";
 
-const BUSINESS_INFO_URL =
-  "https://www.ftc.go.kr/bizCommPop.do?wrkr_no=8706400978";
-
-const footerLinkClass = "text-inherit underline";
+const footerUnderlineClass = "text-inherit underline";
 
 const LandingPage = () => {
   const navigate = useNavigate();
+  const [isBusinessInfoOpen, setIsBusinessInfoOpen] = useState(false);
 
   return (
     <Layout>
@@ -44,23 +43,23 @@ const LandingPage = () => {
             관리자로 로그인
           </Button>
         </div>
-        <p className="mt-[30px] w-full max-w-[322px] text-center text-10px font-normal leading-[1.3] text-neutral-gray-3 whitespace-pre-wrap">
+        <p className="mt-[30px] w-full px-4 text-center text-10px font-normal leading-[1.3] text-neutral-gray-3 whitespace-pre">
           Retrivr  |  대표자: 박다솔  |  사업자등록번호: 870-64-00978
           {"\n"}
-          <span className={footerLinkClass}>이용약관</span>
+          <span className={footerUnderlineClass}>이용약관</span>
           {"  |  "}
-          <span className={footerLinkClass}>개인정보처리방침</span>
+          <span className={footerUnderlineClass}>개인정보처리방침</span>
           {"  | E-mail: retrivr.service@gmail.com\n"}
           {"Instagram: @retrivr_official  |  "}
-          <a
-            href={BUSINESS_INFO_URL}
-            target="_blank"
-            rel="noreferrer"
-            className={footerLinkClass}
+          <button
+            type="button"
+            className={`${footerUnderlineClass} inline cursor-pointer bg-transparent p-0 font-[inherit] text-10px leading-[1.3]`}
+            aria-expanded={isBusinessInfoOpen}
+            onClick={() => setIsBusinessInfoOpen((open) => !open)}
           >
             사업자 추가 정보
-          </a>
-          {"  주소: 경기도 파주시 후곡로 77"}
+          </button>
+          {isBusinessInfoOpen ? "  주소: 경기도 파주시 후곡로 77" : null}
         </p>
       </div>
     </Layout>


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- 랜딩 기본 화면은 주소 없이 두고, 사업자 추가 정보를 누르면 주소가 같은 줄에 나오도록 한다.
- 이용약관·개인정보처리방침은 밑줄만 유지하고 클릭 이벤트는 넣지 않는다.

## ⭐ PR Point (To Reviewer)

- 약관/개인정보처리방침 페이지 연결은 보류한다. 머지하지 않고 PR만 열어 둔 상태다.

## 📷 Screenshot

## 🔔 ETC

- Figma: https://www.figma.com/design/n2RVOSB5OfnWlnpSNqOB0J/Retrivr?node-id=3597-19450


Made with [Cursor](https://cursor.com)