### PR TITLE
형식이 다른 쿠폰 번호는 에러 모달을 보여준다

### DIFF
--- a/src/pages/admin/MembershipPage.tsx
+++ b/src/pages/admin/MembershipPage.tsx
@@ -19,6 +19,7 @@ import type {
 import {
   formatCouponDay,
   formatCouponValidityPeriod,
+  isValidCouponCode,
 } from "../../utils/couponDisplay";
 type BillingCycle = "monthly" | "yearly";
 type CouponAlertType =
@@ -161,6 +162,11 @@ const MembershipPage = () => {
 
   const handleLookupCoupon = () => {
     if (!trimmedCouponCode || lookupCouponMutation.isPending) return;
+
+    if (!isValidCouponCode(trimmedCouponCode)) {
+      setCouponAlertType("notFound");
+      return;
+    }
 
     lookupCouponMutation.mutate(trimmedCouponCode, {
       onSuccess: (coupon) => {

--- a/src/utils/couponDisplay.ts
+++ b/src/utils/couponDisplay.ts
@@ -1,5 +1,11 @@
 import type { AdminCouponLookupResponse } from "../api/admin/admin.type";
 
+/** 영대문자·숫자 4자리 3묶음. 예: YKQ3-SVC3-2JVB */
+export const COUPON_CODE_PATTERN = /^[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+
+export const isValidCouponCode = (couponCode: string): boolean =>
+  COUPON_CODE_PATTERN.test(couponCode);
+
 /** YYYY-MM-DD → YY. MM. DD */
 export const formatCouponDay = (day: string): string => {
   const [year, month, date] = day.split("-");


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- 쿠폰 번호가 `XXXX-XXXX-XXXX` (영대문자·숫자 4자리 3묶음)가 아니면 조회 API를 호출하지 않는다.
- 기존 에러 모달(`쿠폰 번호를 다시 확인해주세요.`)을 띄운다.

## ⭐ PR Point (To Reviewer)

- 입력 예: `YKQ3-SVC3-2JVB`, `CLT3-9GEC-VJRZ`
- 형식 오류와 미존재 쿠폰은 같은 모달 문구를 쓴다.

## 📷 Screenshot

## 🔔 ETC


Made with [Cursor](https://cursor.com)