### PR TITLE
[RTR-338] 쿠폰 이용권 목록 멤버십 쿠폰 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -23,6 +23,7 @@ import type {
   PublicRejectRentalRequestBody,
   PublicRejectRentalResponse,
   AdminCouponLookupResponse,
+  AdminCouponMembershipPassListResponse,
   AdminCouponRegistrationResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
@@ -392,6 +393,17 @@ export const registerAdminCoupon = async ({
   );
   return response.data;
 };
+
+// 쿠폰 이용권 목록 조회
+// - 현재 사용 중·대기 중인 쿠폰 이용권
+// GET /api/admin/v1/memberships/coupons
+export const requestAdminCouponMemberships =
+  async (): Promise<AdminCouponMembershipPassListResponse> => {
+    const response = await apiClient.get<AdminCouponMembershipPassListResponse>(
+      "/api/admin/v1/memberships/coupons",
+    );
+    return response.data;
+  };
 
 // 현재 멤버십 상태 조회
 // - 이용권 목록(쿠폰/구독) 화면에서 현재 이용권 정보를 표시

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -388,6 +388,22 @@ export interface AdminMembershipErrorResponse {
   detail?: string;
 }
 
+// 쿠폰 이용권 목록 조회
+// GET /api/admin/v1/memberships/coupons
+export interface AdminCouponMembershipPassResponse {
+  membershipPassId: string;
+  couponName: string;
+  description: string;
+  durationDays: number;
+  status: string;
+  startAt: string;
+  endAt: string;
+}
+
+export interface AdminCouponMembershipPassListResponse {
+  coupons: AdminCouponMembershipPassResponse[];
+}
+
 // 조직 결제수단 목록 조회
 // GET /api/admin/v1/payment-methods
 export type AdminPaymentMethodProvider = "TOSSPAY" | "KAKAOPAY" | "KGINICIS";

--- a/src/components/membership/CouponVoucherPanel.tsx
+++ b/src/components/membership/CouponVoucherPanel.tsx
@@ -1,26 +1,86 @@
-import {
-  COUPON_USAGE_GUIDE,
-  COUPON_VOUCHERS,
-} from "../../types/voucherList";
+import { COUPON_USAGE_GUIDE } from "../../types/voucherList";
+import { useAdminCouponMemberships } from "../../hooks/queries/useAdminQueries";
+import type { AdminCouponMembershipPassResponse } from "../../api/admin/admin.type";
+import { formatCouponDay } from "../../utils/couponDisplay";
 import MembershipCouponCard from "./MembershipCouponCard";
+import type { MembershipCouponStatus } from "./MembershipStatusBadge";
 import UsageGuideCard from "./UsageGuideCard";
 
-const CouponVoucherPanel = () => (
-  <div className="flex flex-col gap-4">
-    <div className="flex flex-col gap-2.5">
-      {COUPON_VOUCHERS.map((voucher) => (
-        <MembershipCouponCard
-          key={voucher.id}
-          title={voucher.title}
-          eventName={voucher.eventName}
-          status={voucher.status}
-          footerText={voucher.footerText}
-          compact
-        />
-      ))}
+const EMPTY_COUPON_MESSAGE = "등록된 쿠폰 이용권이 없습니다.";
+
+const mapCouponPassStatus = (status: string): MembershipCouponStatus => {
+  const normalized = status.trim().replace(/\s+/g, "").toLowerCase();
+
+  if (["active", "사용중", "이용중"].includes(normalized)) {
+    return "active";
+  }
+  if (["completed", "expired", "ended", "사용완료"].includes(normalized)) {
+    return "completed";
+  }
+  return "pending";
+};
+
+const resolveCouponFooter = (
+  coupon: AdminCouponMembershipPassResponse,
+  status: MembershipCouponStatus,
+): string | undefined => {
+  const startAt = coupon.startAt ? formatCouponDay(coupon.startAt) : "";
+  const endAt = coupon.endAt ? formatCouponDay(coupon.endAt) : "";
+
+  if (status === "pending" && startAt) {
+    return `${startAt} 활성화 예정`;
+  }
+  if (startAt && endAt) {
+    return `사용 기간: ${startAt} ~ ${endAt}`;
+  }
+  return undefined;
+};
+
+const CouponVoucherPanel = () => {
+  const { data, isLoading, isError, isSuccess } = useAdminCouponMemberships();
+  const coupons = data?.coupons ?? [];
+  const showEmptyState =
+    !isLoading && (isError || !isSuccess || coupons.length === 0);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {isLoading ? (
+        <div className="flex min-h-[180px] items-center justify-center">
+          <p className="text-14px font-normal leading-[1.4] text-neutral-gray-3">
+            이용권을 불러오는 중이에요
+          </p>
+        </div>
+      ) : null}
+
+      {showEmptyState ? (
+        <div className="flex min-h-[180px] items-center justify-center">
+          <p className="text-center text-14px font-normal leading-[1.4] text-neutral-gray-3">
+            {EMPTY_COUPON_MESSAGE}
+          </p>
+        </div>
+      ) : null}
+
+      {isSuccess && coupons.length > 0 ? (
+        <div className="flex flex-col gap-2.5">
+          {coupons.map((coupon) => {
+            const status = mapCouponPassStatus(coupon.status);
+            return (
+              <MembershipCouponCard
+                key={coupon.membershipPassId}
+                title={coupon.couponName}
+                eventName={coupon.description}
+                status={status}
+                footerText={resolveCouponFooter(coupon, status)}
+                compact
+              />
+            );
+          })}
+        </div>
+      ) : null}
+
+      <UsageGuideCard items={COUPON_USAGE_GUIDE} />
     </div>
-    <UsageGuideCard items={COUPON_USAGE_GUIDE} />
-  </div>
-);
+  );
+};
 
 export default CouponVoucherPanel;

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -25,6 +25,7 @@ import {
   rejectPublicRental,
   requestAdminCoupon,
   registerAdminCoupon,
+  requestAdminCouponMemberships,
   requestAdminMembership,
   requestAdminPaymentMethods,
   createAdminPaymentMethod,
@@ -35,6 +36,7 @@ import {
 import type {
   AdminCreateItemRequest,
   AdminItemListResponse,
+  AdminCouponMembershipPassListResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
   AdminPaymentMethodListResponse,
@@ -399,7 +401,21 @@ export const useRegisterAdminCoupon = () => {
     mutationFn: (couponId: string) => registerAdminCoupon({ couponId }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["adminMembership"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["adminCouponMemberships"],
+      });
     },
+  });
+};
+
+// 쿠폰 이용권 목록 조회
+// - 이용권 목록 > 쿠폰 이용권 탭
+// GET /api/admin/v1/memberships/coupons
+export const useAdminCouponMemberships = () => {
+  return useQuery<AdminCouponMembershipPassListResponse>({
+    queryKey: ["adminCouponMemberships"],
+    queryFn: requestAdminCouponMemberships,
+    retry: false,
   });
 };
 

--- a/src/types/voucherList.ts
+++ b/src/types/voucherList.ts
@@ -19,23 +19,6 @@ export const HISTORY_PERIOD_LABEL: Record<HistoryPeriodOption, string> = {
   custom: "직접입력",
 };
 
-export const COUPON_VOUCHERS = [
-  {
-    id: "coupon-active",
-    title: "2개월 이용권 쿠폰",
-    eventName: "Retrivr 출시 이벤트",
-    status: "active" as const,
-    footerText: "사용 기간: 26. 05. 01 ~ 26. 06. 30",
-  },
-  {
-    id: "coupon-pending",
-    title: "2개월 이용권 쿠폰",
-    eventName: "Retrivr 출시 이벤트",
-    status: "pending" as const,
-    footerText: "26. 07. 01 활성화 예정",
-  },
-];
-
 export const SUBSCRIPTION_USAGE_GUIDE = [
   "쿠폰 코드를 등록하면 쿠폰 이용권을 사용할 수 있습니다.",
   "쿠폰 이용권은 등록 즉시 활성화됩니다.",

--- a/src/utils/couponDisplay.ts
+++ b/src/utils/couponDisplay.ts
@@ -8,9 +8,17 @@ export const isValidCouponCode = (couponCode: string): boolean =>
 
 /** YYYY-MM-DD → YY. MM. DD */
 export const formatCouponDay = (day: string): string => {
-  const [year, month, date] = day.split("-");
-  if (!year || !month || !date) return day;
-  return `${year.slice(-2)}. ${month}. ${date}`;
+  const isoMatch = day.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) {
+    return `${isoMatch[1].slice(-2)}. ${isoMatch[2]}. ${isoMatch[3]}`;
+  }
+
+  const dottedMatch = day.match(/^(\d{2})\.\s*(\d{2})\.\s*(\d{2})/);
+  if (dottedMatch) {
+    return `${dottedMatch[1]}. ${dottedMatch[2]}. ${dottedMatch[3]}`;
+  }
+
+  return day;
 };
 
 export const formatCouponValidityPeriod = (


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- `GET /api/admin/v1/memberships/coupons`를 이용권 목록 > 쿠폰 이용권 탭에 연동한다.
- mock `COUPON_VOUCHERS`를 제거하고 로딩/빈 목록 상태를 구독 탭과 맞춘다.
- 쿠폰 등록 성공 시 목록 쿼리를 무효화한다.

## ⭐ PR Point (To Reviewer)

- 내부 쿠폰 생성 `POST /api/internal/v1/coupons`는 웹 멤버십 화면용이 아니라 이번 범위에서 빼 두었다.
- API `status` 예시는 `사용전`/`ACTIVE`/`WAITING`이 섞일 수 있어 카드 뱃지(`사용중`/`사용 전`/`사용 완료`)로 매핑한다.

## 📷 Screenshot

## 🔔 ETC


Made with [Cursor](https://cursor.com)