### PR TITLE
[RTR-339] 현재 이용 중인 구독 이용권 조회 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -25,6 +25,7 @@ import type {
   AdminCouponLookupResponse,
   AdminCouponMembershipPassListResponse,
   AdminCouponRegistrationResponse,
+  AdminCurrentSubscriptionResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
   AdminPaymentMethodDeleteResponse,
@@ -401,6 +402,17 @@ export const requestAdminCouponMemberships =
   async (): Promise<AdminCouponMembershipPassListResponse> => {
     const response = await apiClient.get<AdminCouponMembershipPassListResponse>(
       "/api/admin/v1/memberships/coupons",
+    );
+    return response.data;
+  };
+
+// 현재 이용 중인 구독 이용권 조회
+// - 활성화된 패스가 구독일 때만 200. 없으면 404
+// GET /api/admin/v1/memberships/current/subscription
+export const requestAdminCurrentSubscription =
+  async (): Promise<AdminCurrentSubscriptionResponse> => {
+    const response = await apiClient.get<AdminCurrentSubscriptionResponse>(
+      "/api/admin/v1/memberships/current/subscription",
     );
     return response.data;
   };

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -388,6 +388,22 @@ export interface AdminMembershipErrorResponse {
   detail?: string;
 }
 
+// 현재 이용 중인 구독 이용권 조회
+// GET /api/admin/v1/memberships/current/subscription
+export type AdminSubscriptionPlan = "MONTHLY" | "YEARLY";
+export type AdminMembershipPassStatus = "REGISTERED" | "ACTIVE" | "EXPIRED";
+
+export interface AdminCurrentSubscriptionResponse {
+  membershipPassId: string;
+  plan: AdminSubscriptionPlan;
+  membershipPassStatus: AdminMembershipPassStatus;
+  durationDays: number;
+  paidAmount: number;
+  startAt: string;
+  endAt: string;
+  nextBillingAt?: string | null;
+}
+
 // 쿠폰 이용권 목록 조회
 // GET /api/admin/v1/memberships/coupons
 export interface AdminCouponMembershipPassResponse {

--- a/src/components/membership/SubscriptionVoucherPanel.tsx
+++ b/src/components/membership/SubscriptionVoucherPanel.tsx
@@ -1,35 +1,35 @@
-import {
-  SUBSCRIPTION_USAGE_GUIDE,
-} from "../../types/voucherList";
-import { useAdminMembership } from "../../hooks/queries/useAdminQueries";
+import { SUBSCRIPTION_USAGE_GUIDE } from "../../types/voucherList";
+import { useAdminCurrentSubscription } from "../../hooks/queries/useAdminQueries";
+import type { AdminSubscriptionPlan } from "../../api/admin/admin.type";
 import { formatCouponDay } from "../../utils/couponDisplay";
 import UsageGuideCard from "./UsageGuideCard";
 
 const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
 
+const SUBSCRIPTION_PLAN_LABEL: Record<AdminSubscriptionPlan, string> = {
+  MONTHLY: "월간 이용권",
+  YEARLY: "연간 이용권",
+};
+
 type SubscriptionVoucherPanelProps = {
   onCancelSubscription?: () => void;
 };
 
-const isCouponPassType = (passType?: string): boolean =>
-  Boolean(passType && /coupon/i.test(passType));
-
-const resolveStatusLabel = (isPausedForCoupon: boolean): string =>
-  // 현재 패스가 쿠폰일 때만 구독 일시중지 (대기 쿠폰만 있는 경우는 이용중)
-  isPausedForCoupon ? "일시중지" : "이용중";
+const resolveStatusLabel = (status?: string): string =>
+  status === "REGISTERED" ? "일시중지" : "이용중";
 
 const resolveDescription = ({
-  isPausedForCoupon,
+  isPaused,
   nextBillingAt,
 }: {
-  isPausedForCoupon: boolean;
-  nextBillingAt?: string;
+  isPaused: boolean;
+  nextBillingAt?: string | null;
 }): string | undefined => {
   if (!nextBillingAt) return undefined;
 
   const billingDay = formatCouponDay(nextBillingAt);
 
-  if (isPausedForCoupon) {
+  if (isPaused) {
     return `등록된 쿠폰 이용권을 모두 사용하면\n${billingDay}부터 자동 결제가 다시 진행돼요.`;
   }
 
@@ -39,17 +39,18 @@ const resolveDescription = ({
 const SubscriptionVoucherPanel = ({
   onCancelSubscription,
 }: SubscriptionVoucherPanelProps) => {
-  const { data, isLoading, isError, isSuccess } = useAdminMembership();
+  const { data, isLoading, isError, isSuccess } = useAdminCurrentSubscription();
 
-  const subscriptionName = data?.subscriptionInfo?.subscriptionName?.trim();
-  const hasSubscription = Boolean(subscriptionName);
-  const isPausedForCoupon = isCouponPassType(data?.passType);
-  const showEmptyState =
-    !isLoading && (isError || !isSuccess || (isSuccess && !hasSubscription));
-
-  const statusLabel = resolveStatusLabel(isPausedForCoupon);
+  const hasSubscription =
+    isSuccess && Boolean(data) && data?.membershipPassStatus !== "EXPIRED";
+  const showEmptyState = !isLoading && (isError || !hasSubscription);
+  const isPaused = data?.membershipPassStatus === "REGISTERED";
+  const planLabel = data?.plan
+    ? SUBSCRIPTION_PLAN_LABEL[data.plan]
+    : undefined;
+  const statusLabel = resolveStatusLabel(data?.membershipPassStatus);
   const description = resolveDescription({
-    isPausedForCoupon,
+    isPaused,
     nextBillingAt: data?.nextBillingAt,
   });
 
@@ -71,11 +72,11 @@ const SubscriptionVoucherPanel = ({
         </div>
       ) : null}
 
-      {isSuccess && data && hasSubscription && subscriptionName ? (
+      {hasSubscription && data && planLabel ? (
         <article className="flex flex-col rounded-2xl bg-neutral-white px-[26px] py-6 shadow-[0px_0px_16px_-6px_rgba(0,0,0,0.2)]">
           <div className="flex items-center gap-[5px]">
             <h2 className="text-16px font-bold leading-normal text-neutral-gray-1">
-              {subscriptionName}
+              {planLabel}
             </h2>
             <span className="inline-flex h-[18px] items-center justify-center rounded-[9px] border-[0.5px] border-secondary-2 bg-neutral-gray-5 px-[7px]">
               <span className="text-10px font-bold leading-[1.3] text-secondary-2">

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import axios from "axios";
 import {
   requestAdminItemList,
   requestAdminRentalItemSummaryList,
@@ -26,6 +27,7 @@ import {
   requestAdminCoupon,
   registerAdminCoupon,
   requestAdminCouponMemberships,
+  requestAdminCurrentSubscription,
   requestAdminMembership,
   requestAdminPaymentMethods,
   createAdminPaymentMethod,
@@ -37,6 +39,7 @@ import type {
   AdminCreateItemRequest,
   AdminItemListResponse,
   AdminCouponMembershipPassListResponse,
+  AdminCurrentSubscriptionResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
   AdminPaymentMethodListResponse,
@@ -404,6 +407,9 @@ export const useRegisterAdminCoupon = () => {
       await queryClient.invalidateQueries({
         queryKey: ["adminCouponMemberships"],
       });
+      await queryClient.invalidateQueries({
+        queryKey: ["adminCurrentSubscription"],
+      });
     },
   });
 };
@@ -415,6 +421,26 @@ export const useAdminCouponMemberships = () => {
   return useQuery<AdminCouponMembershipPassListResponse>({
     queryKey: ["adminCouponMemberships"],
     queryFn: requestAdminCouponMemberships,
+    retry: false,
+  });
+};
+
+// 현재 이용 중인 구독 이용권 조회
+// - 이용권 목록 > 구독 이용권 탭
+// GET /api/admin/v1/memberships/current/subscription
+export const useAdminCurrentSubscription = () => {
+  return useQuery<AdminCurrentSubscriptionResponse | null>({
+    queryKey: ["adminCurrentSubscription"],
+    queryFn: async () => {
+      try {
+        return await requestAdminCurrentSubscription();
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
     retry: false,
   });
 };

--- a/src/utils/couponDisplay.ts
+++ b/src/utils/couponDisplay.ts
@@ -8,12 +8,14 @@ export const isValidCouponCode = (couponCode: string): boolean =>
 
 /** YYYY-MM-DD → YY. MM. DD */
 export const formatCouponDay = (day: string): string => {
-  const isoMatch = day.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  const datePart = day.includes("T") ? day.slice(0, 10) : day;
+
+  const isoMatch = datePart.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (isoMatch) {
     return `${isoMatch[1].slice(-2)}. ${isoMatch[2]}. ${isoMatch[3]}`;
   }
 
-  const dottedMatch = day.match(/^(\d{2})\.\s*(\d{2})\.\s*(\d{2})/);
+  const dottedMatch = datePart.match(/^(\d{2})\.\s*(\d{2})\.\s*(\d{2})/);
   if (dottedMatch) {
     return `${dottedMatch[1]}. ${dottedMatch[2]}. ${dottedMatch[3]}`;
   }


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- `GET /api/admin/v1/memberships/current/subscription`를 이용권 목록 > 구독 이용권 탭에 연동한다.
- 활성화된 구독이 없으면(404) 빈 상태로 보여준다.
- `MONTHLY`/`YEARLY`를 월간·연간 이용권으로 표시하고, `REGISTERED`는 일시중지로 표시한다.

## ⭐ PR Point (To Reviewer)

- 멤버십 홈의 `GET /memberships/current`는 그대로 둔다.
- 쿠폰 등록 성공 시 구독 탭 쿼리도 무효화한다.

## 📷 Screenshot

## 🔔 ETC


Made with [Cursor](https://cursor.com)