### PR TITLE
[RTR-340] 이용권 및 결제 내역 조회 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -25,6 +25,8 @@ import type {
   AdminCouponLookupResponse,
   AdminCouponMembershipPassListResponse,
   AdminCouponRegistrationResponse,
+  AdminMembershipHistoryParams,
+  AdminMembershipHistoryResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
   AdminPaymentMethodDeleteResponse,
@@ -404,6 +406,18 @@ export const requestAdminCouponMemberships =
     );
     return response.data;
   };
+
+// 이용권 및 결제 내역 조회
+// GET /api/admin/v1/memberships/history
+export const requestAdminMembershipHistory = async (
+  params?: AdminMembershipHistoryParams,
+): Promise<AdminMembershipHistoryResponse> => {
+  const response = await apiClient.get<AdminMembershipHistoryResponse>(
+    "/api/admin/v1/memberships/history",
+    { params },
+  );
+  return response.data;
+};
 
 // 현재 멤버십 상태 조회
 // - 이용권 목록(쿠폰/구독) 화면에서 현재 이용권 정보를 표시

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -404,6 +404,38 @@ export interface AdminCouponMembershipPassListResponse {
   coupons: AdminCouponMembershipPassResponse[];
 }
 
+// 이용권 및 결제 내역 조회
+// GET /api/admin/v1/memberships/history
+export type AdminMembershipHistoryType = "SUBSCRIPTION" | "COUPON";
+export type AdminMembershipHistoryPlan = "MONTHLY" | "YEARLY";
+export type AdminMembershipHistoryStatus =
+  | "REGISTERED"
+  | "ACTIVE"
+  | "EXPIRED";
+
+export interface AdminMembershipHistoryItemResponse {
+  membershipPassId: string;
+  type: AdminMembershipHistoryType;
+  title: string;
+  status: AdminMembershipHistoryStatus;
+  plan?: AdminMembershipHistoryPlan | null;
+  occurredAt: string;
+  amount: number;
+  receiptAvailable: boolean;
+}
+
+export interface AdminMembershipHistoryResponse {
+  items: AdminMembershipHistoryItemResponse[];
+  nextCursor?: number | null;
+}
+
+export interface AdminMembershipHistoryParams {
+  cursor?: number;
+  size?: number;
+  start?: string;
+  end?: string;
+}
+
 // 조직 결제수단 목록 조회
 // GET /api/admin/v1/payment-methods
 export type AdminPaymentMethodProvider = "TOSSPAY" | "KAKAOPAY" | "KGINICIS";

--- a/src/components/membership/UsageHistoryPanel.tsx
+++ b/src/components/membership/UsageHistoryPanel.tsx
@@ -1,15 +1,33 @@
 import { useMemo, useState } from "react";
-import {
-  USAGE_HISTORY_ITEMS,
-  type HistoryPeriodOption,
+import type {
+  HistoryPeriodOption,
+  UsageHistoryItem,
 } from "../../types/voucherList";
+import type { AdminMembershipHistoryItemResponse } from "../../api/admin/admin.type";
+import { useAdminMembershipHistory } from "../../hooks/queries/useAdminQueries";
 import {
   HISTORY_DATE_BOUNDS,
-  filterUsageHistory,
+  formatHistoryAmount,
+  formatHistoryOccurredAt,
+  resolveHistoryQueryRange,
 } from "../../utils/voucherHistory";
 import type { WheelDate } from "./HistoryDateWheel";
 import HistoryPeriodFilter from "./HistoryPeriodFilter";
 import UsageHistoryItemCard from "./UsageHistoryItemCard";
+
+const toUsageHistoryItem = (
+  item: AdminMembershipHistoryItemResponse,
+): UsageHistoryItem => ({
+  id: `${item.membershipPassId}-${item.occurredAt}`,
+  title: item.title,
+  datetimeLabel: formatHistoryOccurredAt(item.occurredAt),
+  occurredAt: item.occurredAt,
+  kind: item.type === "COUPON" ? "coupon" : "payment",
+  amountLabel:
+    item.type === "SUBSCRIPTION" && item.amount > 0
+      ? formatHistoryAmount(item.amount)
+      : undefined,
+});
 
 const UsageHistoryPanel = () => {
   const [isPeriodOpen, setIsPeriodOpen] = useState(false);
@@ -22,15 +40,23 @@ const UsageHistoryPanel = () => {
     HISTORY_DATE_BOUNDS.end,
   );
 
-  const filteredHistory = useMemo(
-    () =>
-      filterUsageHistory(
-        USAGE_HISTORY_ITEMS,
-        period,
-        customStart,
-        customEnd,
-      ),
+  const queryRange = useMemo(
+    () => resolveHistoryQueryRange(period, customStart, customEnd),
     [period, customStart, customEnd],
+  );
+  const {
+    data,
+    isLoading,
+    isError,
+    isSuccess,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useAdminMembershipHistory(queryRange);
+
+  const historyItems = useMemo(
+    () => data?.pages.flatMap((page) => page.items).map(toUsageHistoryItem) ?? [],
+    [data],
   );
 
   const handleSelectPeriod = (next: HistoryPeriodOption) => {
@@ -60,15 +86,46 @@ const UsageHistoryPanel = () => {
       />
 
       <div className="mt-2 flex flex-col gap-2">
-        {filteredHistory.length === 0 ? (
+        {isLoading ? (
+          <p className="py-10 text-center text-12px text-neutral-gray-3">
+            이용 내역을 불러오는 중이에요
+          </p>
+        ) : null}
+
+        {!isLoading && isError && historyItems.length === 0 ? (
+          <p className="py-10 text-center text-12px text-neutral-gray-3">
+            이용 내역을 불러오지 못했어요
+          </p>
+        ) : null}
+
+        {!isLoading && !isError && isSuccess && historyItems.length === 0 ? (
           <p className="py-10 text-center text-12px text-neutral-gray-3">
             선택한 기간의 이용 내역이 없어요
           </p>
-        ) : (
-          filteredHistory.map((item) => (
-            <UsageHistoryItemCard key={item.id} item={item} />
-          ))
-        )}
+        ) : null}
+
+        {historyItems.length > 0
+          ? historyItems.map((item) => (
+              <UsageHistoryItemCard key={item.id} item={item} />
+            ))
+          : null}
+
+        {isError && historyItems.length > 0 ? (
+          <p className="py-3 text-center text-12px text-neutral-gray-3">
+            다음 내역을 불러오지 못했어요
+          </p>
+        ) : null}
+
+        {hasNextPage ? (
+          <button
+            type="button"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="mt-2 py-3 text-center text-12px font-medium text-secondary-2 disabled:text-neutral-gray-3"
+          >
+            {isFetchingNextPage ? "불러오는 중..." : "더 보기"}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -27,6 +27,7 @@ import {
   registerAdminCoupon,
   requestAdminCouponMemberships,
   requestAdminMembership,
+  requestAdminMembershipHistory,
   requestAdminPaymentMethods,
   createAdminPaymentMethod,
   updateAdminDefaultPaymentMethod,
@@ -37,6 +38,7 @@ import type {
   AdminCreateItemRequest,
   AdminItemListResponse,
   AdminCouponMembershipPassListResponse,
+  AdminMembershipHistoryResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
   AdminPaymentMethodListResponse,
@@ -415,6 +417,34 @@ export const useAdminCouponMemberships = () => {
   return useQuery<AdminCouponMembershipPassListResponse>({
     queryKey: ["adminCouponMemberships"],
     queryFn: requestAdminCouponMemberships,
+    retry: false,
+  });
+};
+
+// 이용권 및 결제 내역 조회
+// - 이용권 목록 > 이용 내역 탭
+// GET /api/admin/v1/memberships/history
+export const useAdminMembershipHistory = (params?: {
+  start?: string;
+  end?: string;
+}) => {
+  return useInfiniteQuery<AdminMembershipHistoryResponse>({
+    queryKey: ["adminMembershipHistory", params?.start, params?.end],
+    initialPageParam: undefined as number | undefined,
+    queryFn: ({ pageParam }) =>
+      requestAdminMembershipHistory({
+        cursor: pageParam as number | undefined,
+        size: 15,
+        start: params?.start,
+        end: params?.end,
+      }),
+    getNextPageParam: (lastPage) => {
+      const nextCursor = lastPage.nextCursor;
+      if (typeof nextCursor !== "number" || nextCursor <= 0) {
+        return undefined;
+      }
+      return nextCursor;
+    },
     retry: false,
   });
 };

--- a/src/types/voucherList.ts
+++ b/src/types/voucherList.ts
@@ -30,36 +30,3 @@ export const COUPON_USAGE_GUIDE = [
   "쿠폰 이용권은 등록 즉시 활성화됩니다.",
   "현재 사용 중인 구독 이용권이 있는 경우, 다음 결제 주기(익월)부터 쿠폰 이용권이 우선 적용됩니다.",
 ];
-
-export const USAGE_HISTORY_ITEMS: UsageHistoryItem[] = [
-  {
-    id: "history-1",
-    title: "월간 이용권 결제",
-    datetimeLabel: "2026. 07. 04.(금) 14:32",
-    occurredAt: "2026-07-04",
-    kind: "payment",
-    amountLabel: "4,900₩",
-  },
-  {
-    id: "history-2",
-    title: "2달 이용권 쿠폰 사용",
-    datetimeLabel: "2026. 05. 01.(금) 10:00",
-    occurredAt: "2026-05-01",
-    kind: "coupon",
-  },
-  {
-    id: "history-3",
-    title: "연간 이용권 결제",
-    datetimeLabel: "2026. 03. 31.(월) 11:20",
-    occurredAt: "2026-03-31",
-    kind: "payment",
-    amountLabel: "46,900₩",
-  },
-  {
-    id: "history-4",
-    title: "1달 이용권 쿠폰 사용",
-    datetimeLabel: "2026. 03. 15.(토) 09:20",
-    occurredAt: "2026-03-15",
-    kind: "coupon",
-  },
-];

--- a/src/utils/voucherHistory.ts
+++ b/src/utils/voucherHistory.ts
@@ -1,8 +1,7 @@
 import type { WheelDate } from "../components/membership/HistoryDateWheel";
-import {
-  USAGE_HISTORY_ITEMS,
-  type HistoryPeriodOption,
-  type UsageHistoryItem,
+import type {
+  HistoryPeriodOption,
+  UsageHistoryItem,
 } from "../types/voucherList";
 
 export const parseLocalDate = (isoDate: string) => {
@@ -33,6 +32,14 @@ export const toWheelDate = (date: Date): WheelDate => ({
 export const fromWheelDate = (value: WheelDate) =>
   new Date(value.year, value.month - 1, value.day);
 
+export const toIsoDate = (value: Date | WheelDate): string => {
+  const date = value instanceof Date ? value : fromWheelDate(value);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
 export const shiftMonths = (base: Date, months: number) => {
   const next = new Date(base);
   next.setMonth(next.getMonth() - months);
@@ -40,17 +47,10 @@ export const shiftMonths = (base: Date, months: number) => {
 };
 
 export const HISTORY_DATE_BOUNDS = (() => {
-  if (USAGE_HISTORY_ITEMS.length === 0) {
-    const today = toWheelDate(new Date());
-    return { start: today, end: today };
-  }
-
-  const timestamps = USAGE_HISTORY_ITEMS.map((item) =>
-    parseLocalDate(item.occurredAt).getTime(),
-  );
+  const today = new Date();
   return {
-    start: toWheelDate(new Date(Math.min(...timestamps))),
-    end: toWheelDate(new Date(Math.max(...timestamps))),
+    start: toWheelDate(shiftMonths(today, 60)),
+    end: toWheelDate(today),
   };
 })();
 
@@ -59,6 +59,53 @@ const currentYear = new Date().getFullYear();
 export const HISTORY_YEAR_RANGE = {
   min: Math.min(HISTORY_DATE_BOUNDS.start.year, currentYear - 5),
   max: Math.max(HISTORY_DATE_BOUNDS.end.year, currentYear + 5),
+};
+
+export const resolveHistoryQueryRange = (
+  period: HistoryPeriodOption,
+  customStart: WheelDate,
+  customEnd: WheelDate,
+): { start?: string; end?: string } => {
+  if (period === "all") return {};
+
+  if (period === "custom") {
+    const start = fromWheelDate(customStart);
+    const end = fromWheelDate(customEnd);
+    const from = start <= end ? start : end;
+    const to = start <= end ? end : start;
+    return { start: toIsoDate(from), end: toIsoDate(to) };
+  }
+
+  const months = period === "1m" ? 1 : period === "6m" ? 6 : 12;
+  const today = new Date();
+  return {
+    start: toIsoDate(shiftMonths(today, months)),
+    end: toIsoDate(today),
+  };
+};
+
+export const formatHistoryAmount = (amount: number): string =>
+  `${amount.toLocaleString("ko-KR")}₩`;
+
+const WEEKDAY_LABEL = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+export const formatHistoryOccurredAt = (value: string): string => {
+  const dottedWithWeekday = value.match(
+    /^(\d{4})\.(\d{2})\.(\d{2})\((.+)\)\s*(\d{2}:\d{2})/,
+  );
+  if (dottedWithWeekday) {
+    return `${dottedWithWeekday[1]}. ${dottedWithWeekday[2]}. ${dottedWithWeekday[3]}.(${dottedWithWeekday[4]}) ${dottedWithWeekday[5]}`;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+
+  const year = parsed.getFullYear();
+  const month = String(parsed.getMonth() + 1).padStart(2, "0");
+  const day = String(parsed.getDate()).padStart(2, "0");
+  const hours = String(parsed.getHours()).padStart(2, "0");
+  const minutes = String(parsed.getMinutes()).padStart(2, "0");
+  return `${year}. ${month}. ${day}.(${WEEKDAY_LABEL[parsed.getDay()]}) ${hours}:${minutes}`;
 };
 
 export const filterUsageHistory = (


### PR DESCRIPTION
## 📌 Related Issues

- close #

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- `GET /api/admin/v1/memberships/history`를 이용권 목록 > 이용 내역 탭에 연동한다.
- 기간 필터(전체/1개월/6개월/1년/직접입력)를 API `start`/`end` 쿼리로 보낸다.
- 커서로 다음 페이지를 불러오는 더 보기를 추가한다.
- mock `USAGE_HISTORY_ITEMS`를 제거한다.

## ⭐ PR Point (To Reviewer)

- `SUBSCRIPTION`은 결제 금액, `COUPON`은 쿠폰 사용으로 표시한다.
- 초기 조회 실패와 빈 목록, 다음 페이지 실패 문구를 구분한다.
- [RTR-339](https://github.com/TEAM-Retrivr/RETRIVR-WEB/pull/177)와 브랜치를 분리했다. 둘 다 `admin.api.ts`/`admin.type.ts`/`useAdminQueries.ts`를 건드리므로 머지 순서를 맞추면 충돌을 줄일 수 있다.

## 📷 Screenshot

## 🔔 ETC


Made with [Cursor](https://cursor.com)