### PR TITLE
[RTR-341] 구독 시작 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -27,6 +27,8 @@ import type {
   AdminCouponRegistrationResponse,
   AdminCurrentSubscriptionResponse,
   AdminMembershipHistoryParams,
+  AdminSubscriptionStartRequest,
+  AdminSubscriptionStartResponse,
   AdminMembershipHistoryResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
@@ -427,6 +429,18 @@ export const requestAdminMembershipHistory = async (
   const response = await apiClient.get<AdminMembershipHistoryResponse>(
     "/api/admin/v1/memberships/history",
     { params },
+  );
+  return response.data;
+};
+
+// 구독 시작
+// POST /api/admin/v1/subscriptions
+export const startAdminSubscription = async (
+  body: AdminSubscriptionStartRequest,
+): Promise<AdminSubscriptionStartResponse> => {
+  const response = await apiClient.post<AdminSubscriptionStartResponse>(
+    "/api/admin/v1/subscriptions",
+    body,
   );
   return response.data;
 };

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -391,6 +391,7 @@ export interface AdminMembershipErrorResponse {
 // 현재 이용 중인 구독 이용권 조회
 // GET /api/admin/v1/memberships/current/subscription
 export type AdminSubscriptionPlan = "MONTHLY" | "YEARLY";
+export type AdminSubscriptionStatus = "ACTIVE" | "CANCELED" | "PAYMENT_FAILED";
 export type AdminMembershipPassStatus = "REGISTERED" | "ACTIVE" | "EXPIRED";
 
 export interface AdminCurrentSubscriptionResponse {
@@ -402,6 +403,30 @@ export interface AdminCurrentSubscriptionResponse {
   startAt: string;
   endAt: string;
   nextBillingAt?: string | null;
+}
+
+// 구독 시작
+// POST /api/admin/v1/subscriptions
+export interface AdminSubscriptionStartRequest {
+  plan: AdminSubscriptionPlan;
+  paymentMethodId: string;
+}
+
+export interface AdminSubscriptionStartResponse {
+  subscriptionId: string;
+  plan: AdminSubscriptionPlan;
+  status: AdminSubscriptionStatus;
+  nextBillingAt?: string;
+  membershipPassId: string;
+  startAt: string;
+  expireAt: string;
+}
+
+export interface AdminSubscriptionErrorResponse {
+  status: string;
+  code: number;
+  message: string;
+  detail?: string;
 }
 
 // 쿠폰 이용권 목록 조회

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -30,6 +30,7 @@ import {
   requestAdminCurrentSubscription,
   requestAdminMembership,
   requestAdminMembershipHistory,
+  startAdminSubscription,
   requestAdminPaymentMethods,
   createAdminPaymentMethod,
   updateAdminDefaultPaymentMethod,
@@ -43,6 +44,7 @@ import type {
   AdminCurrentSubscriptionResponse,
   AdminMembershipHistoryResponse,
   AdminMembershipResponse,
+  AdminSubscriptionStartRequest,
   AdminPaymentMethodCreateRequest,
   AdminPaymentMethodListResponse,
   AdminPaymentMethodResponse,
@@ -472,6 +474,27 @@ export const useAdminMembershipHistory = (params?: {
       return nextCursor;
     },
     retry: false,
+  });
+};
+
+// 구독 시작
+// POST /api/admin/v1/subscriptions
+export const useStartAdminSubscription = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: AdminSubscriptionStartRequest) =>
+      startAdminSubscription(body),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["adminMembership"] }),
+        queryClient.invalidateQueries({
+          queryKey: ["adminCurrentSubscription"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["adminMembershipHistory"],
+        }),
+      ]);
+    },
   });
 };
 

--- a/src/pages/admin/VoucherPaymentPage.tsx
+++ b/src/pages/admin/VoucherPaymentPage.tsx
@@ -5,9 +5,13 @@ import { Layout } from "../../components/Layout";
 import Header from "../../components/Header";
 import ConfirmModal from "../../components/modals/ConfirmModal";
 import SubscriptionPaymentMethodSelect from "../../components/membership/SubscriptionPaymentMethodSelect";
-import type { AdminPaymentMethodErrorResponse } from "../../api/admin/admin.type";
+import type {
+  AdminPaymentMethodErrorResponse,
+  AdminSubscriptionErrorResponse,
+} from "../../api/admin/admin.type";
 import {
   useAdminPaymentMethods,
+  useStartAdminSubscription,
   useUpdateAdminDefaultPaymentMethod,
 } from "../../hooks/queries/useAdminQueries";
 import {
@@ -16,6 +20,7 @@ import {
 } from "../../types/paymentMethod";
 import {
   parseVoucherBillingCycle,
+  toAdminSubscriptionPlan,
   VOUCHER_PAYMENT_PLANS,
 } from "../../types/voucherPayment";
 
@@ -29,6 +34,7 @@ const getPaymentMethodErrorMessage = (error: unknown, fallback: string) => {
   if (axios.isAxiosError(error)) {
     const data = error.response?.data as
       | AdminPaymentMethodErrorResponse
+      | AdminSubscriptionErrorResponse
       | undefined;
     if (data?.message) return data.message;
   }
@@ -43,6 +49,8 @@ const VoucherPaymentPage = () => {
   const { data, isLoading, isError } = useAdminPaymentMethods();
   const { mutate: updateDefault, isPending: isUpdatingDefault } =
     useUpdateAdminDefaultPaymentMethod();
+  const { mutate: startSubscription, isPending: isStarting } =
+    useStartAdminSubscription();
   const methods = toActivePaymentMethods(data);
   const primaryId = getPrimaryPaymentMethodId(methods);
   const [selectedId, setSelectedId] = useState("");
@@ -101,9 +109,22 @@ const VoucherPaymentPage = () => {
       setConfirmMessage("결제 수단을 먼저 등록해주세요.");
       return;
     }
-    if (selectedId !== primaryId) {
-      updateDefault(selectedId, {
-        onSuccess: () => {
+    if (isStarting || isUpdatingDefault) return;
+
+    startSubscription(
+      {
+        plan: toAdminSubscriptionPlan(plan.cycle),
+        paymentMethodId: selectedId,
+      },
+      {
+        onSuccess: (data) => {
+          if (data.status === "PAYMENT_FAILED") {
+            setShouldReturnToMembership(false);
+            setConfirmMessage(
+              "결제에 실패했습니다. 결제 수단을 확인한 뒤 다시 시도해주세요.",
+            );
+            return;
+          }
           setShouldReturnToMembership(true);
           setConfirmMessage(`${plan.planLabel}이 시작되었어요.`);
         },
@@ -112,15 +133,12 @@ const VoucherPaymentPage = () => {
           setConfirmMessage(
             getPaymentMethodErrorMessage(
               error,
-              "대표 결제 수단 변경에 실패했습니다. 다시 시도해주세요.",
+              "구독 시작에 실패했습니다. 다시 시도해주세요.",
             ),
           );
         },
-      });
-      return;
-    }
-    setShouldReturnToMembership(true);
-    setConfirmMessage(`${plan.planLabel}이 시작되었어요.`);
+      },
+    );
   };
 
   return (
@@ -191,7 +209,7 @@ const VoucherPaymentPage = () => {
         <div className="pointer-events-none absolute inset-x-0 bottom-0 px-8 pb-8">
           <button
             type="button"
-            disabled={isLoading || isError || isUpdatingDefault}
+            disabled={isLoading || isError || isUpdatingDefault || isStarting}
             onClick={handleStartSubscription}
             className="pointer-events-auto flex h-[50px] w-full items-center justify-center rounded-[12px] bg-primary text-18px font-bold text-neutral-white shadow-primary cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
           >

--- a/src/types/voucherPayment.ts
+++ b/src/types/voucherPayment.ts
@@ -1,3 +1,5 @@
+import type { AdminSubscriptionPlan } from "../api/admin/admin.type";
+
 export type VoucherBillingCycle = "monthly" | "yearly";
 
 export type VoucherPaymentPlan = {
@@ -34,3 +36,7 @@ export const VOUCHER_PAYMENT_PLANS: Record<
 export const parseVoucherBillingCycle = (
   value: string | null,
 ): VoucherBillingCycle => (value === "yearly" ? "yearly" : "monthly");
+
+export const toAdminSubscriptionPlan = (
+  cycle: VoucherBillingCycle,
+): AdminSubscriptionPlan => (cycle === "yearly" ? "YEARLY" : "MONTHLY");


### PR DESCRIPTION
## 📌 Related Issues

- [RTR-341] 구독 시작 API 연동

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요?
- [x] 빌드가 성공했나요? (`npx tsc -b --noEmit`)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- `POST /api/admin/v1/subscriptions`를 이용권 구독 시작 화면에 연결
- 결제 실패(`PAYMENT_FAILED`)와 API 에러를 성공 모달과 분리
- 성공 시 멤버십/구독/히스토리 쿼리 무효화

## ⭐ PR Point (To Reviewer)

- 기존에는 결제수단 기본값 변경만 하거나 모달만 띄웠습니다. 이제 선택 플랜과 `paymentMethodId`로 구독을 생성합니다.

## 📷 Screenshot

## 🔔 ETC

- Bugbot: no findings


Made with [Cursor](https://cursor.com)