### PR TITLE
[RTR-343] 구독 해지 API 연동

### DIFF
--- a/src/api/admin/admin.api.ts
+++ b/src/api/admin/admin.api.ts
@@ -31,6 +31,7 @@ import type {
   AdminSubscriptionStartResponse,
   AdminSubscriptionPlanChangeRequest,
   AdminSubscriptionPlanChangeResponse,
+  AdminSubscriptionCancelResponse,
   AdminMembershipHistoryResponse,
   AdminMembershipResponse,
   AdminPaymentMethodCreateRequest,
@@ -458,6 +459,16 @@ export const changeAdminSubscriptionPlan = async (
   );
   return response.data;
 };
+
+// 구독 해지
+// PATCH /api/admin/v1/subscriptions/me/cancel
+export const cancelAdminSubscription =
+  async (): Promise<AdminSubscriptionCancelResponse> => {
+    const response = await apiClient.patch<AdminSubscriptionCancelResponse>(
+      "/api/admin/v1/subscriptions/me/cancel",
+    );
+    return response.data;
+  };
 
 // 현재 멤버십 상태 조회
 // - 이용권 목록(쿠폰/구독) 화면에서 현재 이용권 정보를 표시

--- a/src/api/admin/admin.type.ts
+++ b/src/api/admin/admin.type.ts
@@ -441,6 +441,15 @@ export interface AdminSubscriptionPlanChangeResponse {
   nextBillingAt?: string;
 }
 
+// 구독 해지
+// PATCH /api/admin/v1/subscriptions/me/cancel
+export interface AdminSubscriptionCancelResponse {
+  subscriptionId: string;
+  status: AdminSubscriptionStatus;
+  canceledAt?: string;
+  currentPassExpireAt?: string;
+}
+
 // 쿠폰 이용권 목록 조회
 // GET /api/admin/v1/memberships/coupons
 export interface AdminCouponMembershipPassResponse {

--- a/src/components/membership/SubscriptionVoucherPanel.tsx
+++ b/src/components/membership/SubscriptionVoucherPanel.tsx
@@ -1,8 +1,18 @@
+import { useState } from "react";
+import axios from "axios";
 import { SUBSCRIPTION_USAGE_GUIDE } from "../../types/voucherList";
-import { useAdminCurrentSubscription } from "../../hooks/queries/useAdminQueries";
-import type { AdminSubscriptionPlan } from "../../api/admin/admin.type";
+import {
+  useAdminCurrentSubscription,
+  useCancelAdminSubscription,
+} from "../../hooks/queries/useAdminQueries";
+import type {
+  AdminSubscriptionErrorResponse,
+  AdminSubscriptionPlan,
+} from "../../api/admin/admin.type";
 import { formatCouponDay } from "../../utils/couponDisplay";
 import UsageGuideCard from "./UsageGuideCard";
+import SubscriptionCancelModal from "../modals/membership/SubscriptionCancelModal";
+import CouponAlertModal from "../modals/membership/CouponAlertModal";
 
 const EMPTY_MEMBERSHIP_MESSAGE = "현재 이용 중인 이용권이 없습니다.";
 
@@ -11,8 +21,14 @@ const SUBSCRIPTION_PLAN_LABEL: Record<AdminSubscriptionPlan, string> = {
   YEARLY: "연간 이용권",
 };
 
-type SubscriptionVoucherPanelProps = {
-  onCancelSubscription?: () => void;
+const getSubscriptionErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as
+      | AdminSubscriptionErrorResponse
+      | undefined;
+    if (data?.message) return data.message;
+  }
+  return fallback;
 };
 
 const resolveStatusLabel = (status?: string): string =>
@@ -36,10 +52,12 @@ const resolveDescription = ({
   return `다음 결제 예정일: ${billingDay}`;
 };
 
-const SubscriptionVoucherPanel = ({
-  onCancelSubscription,
-}: SubscriptionVoucherPanelProps) => {
+const SubscriptionVoucherPanel = () => {
   const { data, isLoading, isError, isSuccess } = useAdminCurrentSubscription();
+  const cancelMutation = useCancelAdminSubscription();
+  const [isCancelOpen, setIsCancelOpen] = useState(false);
+  const [resultMessage, setResultMessage] = useState<string | null>(null);
+  const [hasCanceled, setHasCanceled] = useState(false);
 
   const hasSubscription =
     isSuccess && Boolean(data) && data?.membershipPassStatus !== "EXPIRED";
@@ -53,6 +71,31 @@ const SubscriptionVoucherPanel = ({
     isPaused,
     nextBillingAt: data?.nextBillingAt,
   });
+
+  const handleConfirmCancel = async () => {
+    if (cancelMutation.isPending) return;
+    try {
+      const response = await cancelMutation.mutateAsync();
+      setHasCanceled(true);
+      setIsCancelOpen(false);
+      const expireDay = response.currentPassExpireAt
+        ? formatCouponDay(response.currentPassExpireAt)
+        : undefined;
+      setResultMessage(
+        expireDay
+          ? `구독이 해지되었어요.\n이용권은 ${expireDay}까지 유지됩니다.`
+          : "구독이 해지되었어요.",
+      );
+    } catch (error) {
+      setIsCancelOpen(false);
+      setResultMessage(
+        getSubscriptionErrorMessage(
+          error,
+          "구독 해지에 실패했습니다. 다시 시도해주세요.",
+        ),
+      );
+    }
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -85,23 +128,42 @@ const SubscriptionVoucherPanel = ({
             </span>
           </div>
 
-          {description ? (
+          {description && !hasCanceled ? (
             <p className="mt-2 whitespace-pre-line text-12px font-normal leading-[1.4] text-neutral-gray-3">
               {description}
             </p>
           ) : null}
 
-          <button
-            type="button"
-            onClick={onCancelSubscription}
-            className="mt-4 self-end text-12px font-medium leading-[1.5] text-neutral-gray-3 underline cursor-pointer"
-          >
-            구독 해지
-          </button>
+          {!hasCanceled && data.nextBillingAt ? (
+            <button
+              type="button"
+              onClick={() => setIsCancelOpen(true)}
+              disabled={cancelMutation.isPending}
+              className="mt-4 self-end text-12px font-medium leading-[1.5] text-neutral-gray-3 underline cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              구독 해지
+            </button>
+          ) : null}
         </article>
       ) : null}
 
       <UsageGuideCard items={SUBSCRIPTION_USAGE_GUIDE} />
+
+      <SubscriptionCancelModal
+        isOpen={isCancelOpen}
+        isPending={cancelMutation.isPending}
+        onClose={() => {
+          if (cancelMutation.isPending) return;
+          setIsCancelOpen(false);
+        }}
+        onConfirm={handleConfirmCancel}
+      />
+
+      <CouponAlertModal
+        isOpen={resultMessage !== null}
+        message={resultMessage ?? ""}
+        onClose={() => setResultMessage(null)}
+      />
     </div>
   );
 };

--- a/src/components/modals/membership/SubscriptionCancelModal.tsx
+++ b/src/components/modals/membership/SubscriptionCancelModal.tsx
@@ -1,0 +1,56 @@
+import { Modal } from "../../Modal";
+import Button from "../../Button";
+
+type SubscriptionCancelModalProps = {
+  isOpen: boolean;
+  isPending?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const SubscriptionCancelModal = ({
+  isOpen,
+  isPending = false,
+  onClose,
+  onConfirm,
+}: SubscriptionCancelModalProps) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    showTitle={false}
+    showCloseButton={false}
+    modalClassName="!w-[338px] !rounded-[24px] !px-4 !pt-10 !pb-6 shadow-[0_0_16px_-6px_rgba(0,0,0,0.2)]"
+  >
+    <div className="flex w-full flex-col items-center font-[Pretendard]">
+      <p className="text-center text-20px font-semibold leading-[1.4] text-secondary-1">
+        구독을 해지하시겠어요?
+      </p>
+      <p className="mt-2 text-center text-12px font-normal leading-[1.4] text-neutral-gray-3">
+        해지해도 현재 이용권은 만료일까지 사용할 수 있어요.
+      </p>
+
+      <div className="mt-6 flex h-12 w-full gap-2">
+        <Button
+          variant="outline"
+          size="md"
+          className="h-12 max-w-none flex-1 rounded-[12px] text-18px"
+          disabled={isPending}
+          onClick={onClose}
+        >
+          취소
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
+          className="h-12 max-w-none flex-1 rounded-[12px] text-18px shadow-[0_0_4px_rgba(181,244,255,0.5)]"
+          disabled={isPending}
+          onClick={onConfirm}
+        >
+          {isPending ? "해지 중..." : "해지하기"}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+);
+
+export default SubscriptionCancelModal;

--- a/src/hooks/queries/useAdminQueries.ts
+++ b/src/hooks/queries/useAdminQueries.ts
@@ -32,6 +32,7 @@ import {
   requestAdminMembershipHistory,
   startAdminSubscription,
   changeAdminSubscriptionPlan,
+  cancelAdminSubscription,
   requestAdminPaymentMethods,
   createAdminPaymentMethod,
   updateAdminDefaultPaymentMethod,
@@ -507,6 +508,26 @@ export const useChangeAdminSubscriptionPlan = () => {
   return useMutation({
     mutationFn: (body: AdminSubscriptionPlanChangeRequest) =>
       changeAdminSubscriptionPlan(body),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["adminMembership"] }),
+        queryClient.invalidateQueries({
+          queryKey: ["adminCurrentSubscription"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["adminMembershipHistory"],
+        }),
+      ]);
+    },
+  });
+};
+
+// 구독 해지
+// PATCH /api/admin/v1/subscriptions/me/cancel
+export const useCancelAdminSubscription = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => cancelAdminSubscription(),
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["adminMembership"] }),

--- a/src/pages/admin/VoucherListPage.tsx
+++ b/src/pages/admin/VoucherListPage.tsx
@@ -18,11 +18,7 @@ const VoucherListPage = () => {
         <VoucherListTabs activeTab={activeTab} onChange={setActiveTab} />
 
         <div className="mt-8 flex flex-col gap-4">
-          {activeTab === "subscription" ? (
-            <SubscriptionVoucherPanel
-              onCancelSubscription={() => alert("개발 예정입니다.")}
-            />
-          ) : null}
+          {activeTab === "subscription" ? <SubscriptionVoucherPanel /> : null}
           {activeTab === "coupon" ? <CouponVoucherPanel /> : null}
           {activeTab === "history" ? <UsageHistoryPanel /> : null}
         </div>


### PR DESCRIPTION
## 📌 Related Issues

- [RTR-343] 구독 해지 API 연동

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요?
- [x] 빌드가 성공했나요? (`npx tsc -b --noEmit`)
- [x] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어를 지정했나요? (업무 유형 라벨은 PR Auto Label이 브랜치/변경 파일 기준으로 자동 지정)

## 📄 Tasks

- `PATCH /api/admin/v1/subscriptions/me/cancel`를 이용권 목록 구독 해지에 연결
- 해지 확인 모달 추가, 성공 시 만료일 안내
- 해지 후(또는 다음 결제일이 없으면) 해지 버튼 숨김

## ⭐ PR Point (To Reviewer)

- 해지는 자동 결제만 중단하고 현재 이용권은 만료일까지 유지됩니다.

## 📷 Screenshot

## 🔔 ETC

- Bugbot: 해지 후 버튼 잔존(medium) 반영


Made with [Cursor](https://cursor.com)